### PR TITLE
Add multi-layer validation, fixture generation, and hardened non-voice pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ CPU-only Rust CLI to extract non-voice timeline windows from media, tag windows,
 - `timeline tag <input_media> --input segments.json --output tagged.json`
 - `timeline prompt <input_json> --output prompted.json`
 - `timeline calibrate <corrections_dir> --profile drama`
+- `timeline gen-fixtures --output-dir testdata/generated`
+- `timeline validate <input_media> --truth-json testdata/generated/alternating.truth.json --profile synthetic`
+- `timeline validate <input_media> --subtitles in.srt --total-ms 120000 --profile movie`
+- `timeline validate <input_media> --dataset-manifest speech.csv --total-ms 120000 --profile dataset`
 - `timeline bench <input_media> --output analysis/benchmarks/latest.json`
 
 ## Build

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,4 +40,23 @@ pub enum Commands {
         #[arg(long, default_value = "analysis/benchmarks/latest.json")]
         output: PathBuf,
     },
+    GenFixtures {
+        #[arg(long, default_value = "testdata/generated")]
+        output_dir: PathBuf,
+    },
+    Validate {
+        input_media: PathBuf,
+        #[arg(long)]
+        truth_json: Option<PathBuf>,
+        #[arg(long)]
+        subtitles: Option<PathBuf>,
+        #[arg(long)]
+        dataset_manifest: Option<PathBuf>,
+        #[arg(long)]
+        total_ms: Option<u64>,
+        #[arg(long, default_value = "movie")]
+        profile: String,
+        #[arg(long, default_value = "analysis/validation/latest.json")]
+        output: PathBuf,
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod io;
 pub mod learning;
 pub mod pipeline;
 pub mod types;
+pub mod validation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,9 @@ mod io;
 mod learning;
 mod pipeline;
 mod types;
+mod validation;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
 use tracing::{info, Level};
 use tracing_subscriber::EnvFilter;
@@ -69,10 +70,81 @@ fn run() -> Result<()> {
             let benchmark = benchmark_file(&input_media)?;
             write_json_pretty(&output, &benchmark)?;
         }
+        Commands::GenFixtures { output_dir } => {
+            validation::synthetic::generate_suite(&output_dir)?;
+        }
+        Commands::Validate {
+            input_media,
+            truth_json,
+            subtitles,
+            dataset_manifest,
+            total_ms,
+            profile,
+            output,
+        } => {
+            let cfg = config::AnalysisConfig::default();
+            if let Some(truth_json) = truth_json {
+                let tolerance_ms = tolerance_for_profile(&profile);
+                validation::validate_file(
+                    &input_media,
+                    &truth_json,
+                    &output,
+                    &cfg,
+                    tolerance_ms,
+                    &profile,
+                )?;
+            } else if let Some(subtitles) = subtitles {
+                let srt = std::fs::read_to_string(&subtitles)?;
+                let speech = validation::srt::parse_srt_segments(&srt)?;
+                let total = total_ms.context("--total-ms required for subtitle validation")?;
+                let truth = validation::timeline_from_speech_segments(
+                    input_media.display().to_string(),
+                    16000,
+                    20,
+                    &speech,
+                    total,
+                    1000,
+                );
+                let predicted = extract_timeline(&input_media, &cfg)?;
+                let report = validation::validate_against_timeline(
+                    &predicted,
+                    &truth,
+                    &profile,
+                    tolerance_for_profile(&profile),
+                );
+                write_json_pretty(&output, &report)?;
+            } else if let Some(dataset_manifest) = dataset_manifest {
+                let total = total_ms.context("--total-ms required for dataset validation")?;
+                let truth = validation::dataset::build_truth_from_manifest(
+                    &dataset_manifest,
+                    &input_media.display().to_string(),
+                    total,
+                    1000,
+                )?;
+                let predicted = extract_timeline(&input_media, &cfg)?;
+                let report = validation::validate_against_timeline(
+                    &predicted,
+                    &truth,
+                    &profile,
+                    tolerance_for_profile(&profile),
+                );
+                write_json_pretty(&output, &report)?;
+            } else {
+                bail!("provide one of --truth-json, --subtitles, or --dataset-manifest")
+            }
+        }
     }
 
     info!("timeline command end");
     Ok(())
+}
+
+fn tolerance_for_profile(profile: &str) -> u64 {
+    match profile {
+        "synthetic" => 100,
+        "dataset" => 200,
+        _ => 400,
+    }
 }
 
 fn init_logging() {

--- a/src/pipeline/features.rs
+++ b/src/pipeline/features.rs
@@ -2,11 +2,22 @@
 pub struct FeatureSet {
     pub rms: f32,
     pub zcr: f32,
+    pub spectral_flux: f32,
+    pub centroid_hz: f32,
+    pub low_band_ratio: f32,
+    pub high_band_ratio: f32,
 }
 
-pub fn compute_features(samples: &[f32]) -> FeatureSet {
+pub fn compute_features(samples: &[f32], sample_rate: u32) -> FeatureSet {
     if samples.is_empty() {
-        return FeatureSet { rms: 0.0, zcr: 0.0 };
+        return FeatureSet {
+            rms: 0.0,
+            zcr: 0.0,
+            spectral_flux: 0.0,
+            centroid_hz: 0.0,
+            low_band_ratio: 0.0,
+            high_band_ratio: 0.0,
+        };
     }
     let rms = (samples.iter().map(|v| v * v).sum::<f32>() / samples.len() as f32).sqrt();
     let mut zero_crosses = 0u32;
@@ -15,8 +26,44 @@ pub fn compute_features(samples: &[f32]) -> FeatureSet {
             zero_crosses += 1;
         }
     }
+    let zcr = zero_crosses as f32 / samples.len() as f32;
+
+    let mut flux_acc = 0.0;
+    let win = 256usize;
+    let mut prev_energy = 0.0;
+    let mut weighted_bin_sum = 0.0;
+    let mut mag_sum = 0.0;
+    let mut low = 0.0;
+    let mut high = 0.0;
+    for chunk in samples.chunks(win) {
+        let energy = chunk.iter().map(|v| v.abs()).sum::<f32>() / chunk.len() as f32;
+        flux_acc += (energy - prev_energy).max(0.0);
+        prev_energy = energy;
+
+        for (i, s) in chunk.iter().enumerate() {
+            let freq = i as f32 * sample_rate as f32 / win as f32;
+            let mag = s.abs();
+            weighted_bin_sum += freq * mag;
+            mag_sum += mag;
+            if freq < 300.0 {
+                low += mag;
+            }
+            if freq > 2000.0 {
+                high += mag;
+            }
+        }
+    }
+
     FeatureSet {
         rms,
-        zcr: zero_crosses as f32 / samples.len() as f32,
+        zcr,
+        spectral_flux: flux_acc / samples.len().max(1) as f32,
+        centroid_hz: if mag_sum > 0.0 {
+            weighted_bin_sum / mag_sum
+        } else {
+            0.0
+        },
+        low_band_ratio: if mag_sum > 0.0 { low / mag_sum } else { 0.0 },
+        high_band_ratio: if mag_sum > 0.0 { high / mag_sum } else { 0.0 },
     }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -9,21 +9,38 @@ pub mod vad;
 
 use anyhow::Result;
 use std::{path::Path, time::Instant};
+use tracing::info;
 
 use crate::config::AnalysisConfig;
 use crate::types::{BenchmarkResult, TimelineOutput};
 
 pub fn extract_timeline(input: &Path, cfg: &AnalysisConfig) -> Result<TimelineOutput> {
+    info!(input = %input.display(), sample_rate = cfg.sample_rate_hz, frame_ms = cfg.frame_ms, "extract start");
+    let stage = Instant::now();
     let (samples, source_rate) = decode::decode_audio(input)?;
+    info!(
+        ms = stage.elapsed().as_millis(),
+        source_rate,
+        samples = samples.len(),
+        "decode stage done"
+    );
+
     let mono16k = resample::resample_linear(&samples, source_rate, cfg.sample_rate_hz);
     let frames = framing::build_frames(&mono16k, cfg.sample_rate_hz, cfg.frame_ms);
     let speech = vad::classify_frames(&frames, cfg.energy_threshold);
     let smoothed = segmenter::smooth_speech(&speech, cfg.frame_ms, cfg.speech_hangover_ms);
     let speech_segments = segmenter::speech_segments(&smoothed, cfg.frame_ms, cfg.min_speech_ms);
+    let merged_speech = segmenter::merge_close_segments(&speech_segments, cfg.merge_gap_ms);
     let non_voice = segmenter::invert_to_non_voice(
-        &speech_segments,
+        &merged_speech,
         mono16k.len() as u64 * 1000 / cfg.sample_rate_hz as u64,
         cfg.min_non_voice_ms,
+    );
+    info!(
+        frames = frames.len(),
+        speech_segments = merged_speech.len(),
+        non_voice_segments = non_voice.len(),
+        "extract done"
     );
     Ok(TimelineOutput {
         file: input
@@ -46,8 +63,9 @@ pub fn benchmark_file(input: &Path) -> Result<BenchmarkResult> {
     let speech = vad::classify_frames(&frames, 0.015);
     let smoothed = segmenter::smooth_speech(&speech, 20, 300);
     let speech_segments = segmenter::speech_segments(&smoothed, 20, 120);
+    let merged = segmenter::merge_close_segments(&speech_segments, 250);
     let non_voice =
-        segmenter::invert_to_non_voice(&speech_segments, mono16k.len() as u64 * 1000 / 16000, 1000);
+        segmenter::invert_to_non_voice(&merged, mono16k.len() as u64 * 1000 / 16000, 1000);
     Ok(BenchmarkResult {
         input_file: input.display().to_string(),
         total_ms: start.elapsed().as_millis(),

--- a/src/pipeline/prompts.rs
+++ b/src/pipeline/prompts.rs
@@ -18,12 +18,15 @@ pub fn add_prompts(timeline: &mut TimelineOutput) {
 
 fn prompt_for_tags(tags: &[String]) -> String {
     if tags.iter().any(|t| t == "impact_heavy") {
-        return "No dialogue. Rapid impact sounds and heightened action energy.".to_string();
+        return "No dialogue. Energetic impact-forward soundscape.".to_string();
     }
-    if tags.iter().any(|t| t == "ambience") {
-        return "No dialogue. Ambient environmental sound without speech.".to_string();
+    if tags.iter().any(|t| t == "music_bed") {
+        return "No dialogue. Background music bed without spoken words.".to_string();
     }
-    "No dialogue. Soft background score with low intensity.".to_string()
+    if tags.iter().any(|t| t == "nature_like") {
+        return "No dialogue. Ambient natural atmosphere.".to_string();
+    }
+    "No dialogue. Ambient environmental sound.".to_string()
 }
 
 #[cfg(test)]
@@ -47,6 +50,9 @@ mod tests {
             }],
         };
         add_prompts(&mut t);
-        assert!(t.segments[0].prompt.is_some());
+        assert_eq!(
+            t.segments[0].prompt.clone().unwrap_or_default(),
+            "No dialogue. Ambient environmental sound."
+        );
     }
 }

--- a/src/pipeline/segmenter.rs
+++ b/src/pipeline/segmenter.rs
@@ -15,6 +15,13 @@ pub fn smooth_speech(raw: &[bool], frame_ms: u32, hangover_ms: u32) -> Vec<bool>
             }
         }
     }
+
+    // remove isolated one-frame flicker
+    for i in 1..out.len().saturating_sub(1) {
+        if out[i] && !out[i - 1] && !out[i + 1] {
+            out[i] = false;
+        }
+    }
     out
 }
 
@@ -27,14 +34,7 @@ pub fn speech_segments(smoothed: &[bool], frame_ms: u32, min_speech_ms: u32) -> 
             (Some(s), false) => {
                 let end = i as u64 * frame_ms as u64;
                 if end - s >= min_speech_ms as u64 {
-                    segs.push(Segment {
-                        start_ms: s,
-                        end_ms: end,
-                        kind: SegmentKind::Speech,
-                        confidence: 0.8,
-                        tags: vec![],
-                        prompt: None,
-                    });
+                    segs.push(speech_seg(s, end));
                 }
                 start = None;
             }
@@ -44,17 +44,28 @@ pub fn speech_segments(smoothed: &[bool], frame_ms: u32, min_speech_ms: u32) -> 
     if let Some(s) = start {
         let end = smoothed.len() as u64 * frame_ms as u64;
         if end - s >= min_speech_ms as u64 {
-            segs.push(Segment {
-                start_ms: s,
-                end_ms: end,
-                kind: SegmentKind::Speech,
-                confidence: 0.8,
-                tags: vec![],
-                prompt: None,
-            });
+            segs.push(speech_seg(s, end));
         }
     }
     segs
+}
+
+pub fn merge_close_segments(segments: &[Segment], merge_gap_ms: u32) -> Vec<Segment> {
+    if segments.is_empty() {
+        return Vec::new();
+    }
+    let mut merged = vec![segments[0].clone()];
+    for seg in segments.iter().skip(1) {
+        if let Some(last) = merged.last_mut() {
+            if seg.start_ms <= last.end_ms + merge_gap_ms as u64 && last.kind == seg.kind {
+                last.end_ms = last.end_ms.max(seg.end_ms);
+                last.confidence = last.confidence.min(seg.confidence);
+            } else {
+                merged.push(seg.clone());
+            }
+        }
+    }
+    merged
 }
 
 pub fn invert_to_non_voice(
@@ -76,6 +87,17 @@ pub fn invert_to_non_voice(
     out
 }
 
+fn speech_seg(start_ms: u64, end_ms: u64) -> Segment {
+    Segment {
+        start_ms,
+        end_ms,
+        kind: SegmentKind::Speech,
+        confidence: 0.8,
+        tags: vec![],
+        prompt: None,
+    }
+}
+
 fn push_nv(out: &mut Vec<Segment>, start: u64, end: u64, min_ms: u32) {
     if end.saturating_sub(start) >= min_ms as u64 {
         out.push(Segment {
@@ -94,17 +116,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn inversion_works() {
-        let speech = vec![Segment {
-            start_ms: 1000,
-            end_ms: 2000,
-            kind: SegmentKind::Speech,
-            confidence: 1.0,
-            tags: vec![],
-            prompt: None,
-        }];
-        let inv = invert_to_non_voice(&speech, 4000, 500);
-        assert_eq!(inv.len(), 2);
-        assert_eq!(inv[0].start_ms, 0);
+    fn merge_gap_works() {
+        let speech = vec![speech_seg(0, 200), speech_seg(300, 500)];
+        let merged = merge_close_segments(&speech, 120);
+        assert_eq!(merged.len(), 1);
     }
 }

--- a/src/pipeline/tags.rs
+++ b/src/pipeline/tags.rs
@@ -14,29 +14,37 @@ pub fn add_tags(input_media: &Path, timeline: &mut TimelineOutput) -> Result<()>
         let start = (seg.start_ms * sr as u64 / 1000) as usize;
         let end = (seg.end_ms * sr as u64 / 1000) as usize;
         let clip = &samples[start.min(samples.len())..end.min(samples.len())];
-        let f = compute_features(clip);
-        seg.tags = map_tags(f.rms, f.zcr);
+        let f = compute_features(clip, sr);
+        seg.tags = map_tags(f);
     }
     Ok(())
 }
 
-fn map_tags(rms: f32, zcr: f32) -> Vec<String> {
+fn map_tags(f: crate::pipeline::features::FeatureSet) -> Vec<String> {
     let mut tags = Vec::new();
-    if rms < 0.01 {
-        tags.push("low_intensity".into());
+    if f.rms < 0.012 {
         tags.push("ambience".into());
-    } else if rms > 0.08 {
-        tags.push("high_intensity".into());
-        tags.push("impact_heavy".into());
-    } else {
+    }
+    if f.low_band_ratio > 0.25 && f.rms > 0.015 {
         tags.push("music_bed".into());
     }
-    if zcr > 0.2 {
+    if f.spectral_flux > 0.01 && f.rms > 0.05 {
+        tags.push("impact_heavy".into());
+    }
+    if f.centroid_hz > 1800.0 && f.zcr > 0.15 {
         tags.push("machinery_like".into());
     }
-    if tags.is_empty() {
-        tags.push("unclassified_non_voice".into());
+    if f.low_band_ratio > 0.35 && f.zcr > 0.12 {
+        tags.push("crowd_like".into());
     }
+    if f.high_band_ratio < 0.1 && f.rms < 0.03 {
+        tags.push("nature_like".into());
+    }
+    if tags.is_empty() {
+        tags.push("ambience".into());
+    }
+    tags.sort();
+    tags.dedup();
     tags
 }
 
@@ -46,6 +54,14 @@ mod tests {
 
     #[test]
     fn tag_mapping_stable() {
-        assert!(map_tags(0.0, 0.0).contains(&"ambience".to_string()));
+        let f = crate::pipeline::features::FeatureSet {
+            rms: 0.0,
+            zcr: 0.0,
+            spectral_flux: 0.0,
+            centroid_hz: 0.0,
+            low_band_ratio: 0.2,
+            high_band_ratio: 0.0,
+        };
+        assert!(map_tags(f).contains(&"ambience".to_string()));
     }
 }

--- a/src/validation/compare.rs
+++ b/src/validation/compare.rs
@@ -1,0 +1,142 @@
+use crate::types::{Segment, SegmentKind};
+
+#[derive(Debug, Clone, Copy)]
+pub struct CompareMetrics {
+    pub overlap_ratio: f32,
+    pub boundary_error_ms: f32,
+    pub speech_precision: f32,
+    pub speech_recall: f32,
+    pub non_voice_precision: f32,
+    pub non_voice_recall: f32,
+}
+
+pub fn score_segments(pred: &[Segment], truth: &[Segment], tolerance_ms: u64) -> CompareMetrics {
+    let overlap_ratio = overlap_ratio(pred, truth);
+    let boundary_error_ms = boundary_error(pred, truth);
+    let (speech_precision, speech_recall) =
+        precision_recall(pred, truth, SegmentKind::Speech, tolerance_ms);
+    let (non_voice_precision, non_voice_recall) =
+        precision_recall(pred, truth, SegmentKind::NonVoice, tolerance_ms);
+    CompareMetrics {
+        overlap_ratio,
+        boundary_error_ms,
+        speech_precision,
+        speech_recall,
+        non_voice_precision,
+        non_voice_recall,
+    }
+}
+
+fn precision_recall(
+    pred: &[Segment],
+    truth: &[Segment],
+    kind: SegmentKind,
+    tol: u64,
+) -> (f32, f32) {
+    let pred_k: Vec<_> = pred.iter().filter(|s| s.kind == kind).collect();
+    let truth_k: Vec<_> = truth.iter().filter(|s| s.kind == kind).collect();
+    if pred_k.is_empty() && truth_k.is_empty() {
+        return (1.0, 1.0);
+    }
+    let mut matched_truth = vec![false; truth_k.len()];
+    let mut tp = 0u32;
+    for p in &pred_k {
+        if let Some(idx) = truth_k.iter().enumerate().find_map(|(i, t)| {
+            if matched_truth[i] {
+                return None;
+            }
+            let start_ok = p.start_ms.abs_diff(t.start_ms) <= tol;
+            let end_ok = p.end_ms.abs_diff(t.end_ms) <= tol;
+            if start_ok && end_ok {
+                Some(i)
+            } else {
+                None
+            }
+        }) {
+            matched_truth[idx] = true;
+            tp += 1;
+        }
+    }
+    let precision = if pred_k.is_empty() {
+        1.0
+    } else {
+        tp as f32 / pred_k.len() as f32
+    };
+    let recall = if truth_k.is_empty() {
+        1.0
+    } else {
+        tp as f32 / truth_k.len() as f32
+    };
+    (precision, recall)
+}
+
+fn overlap_ratio(pred: &[Segment], truth: &[Segment]) -> f32 {
+    let p: Vec<_> = pred.iter().map(|s| (s.start_ms, s.end_ms)).collect();
+    let t: Vec<_> = truth.iter().map(|s| (s.start_ms, s.end_ms)).collect();
+    let intersection: u64 = p
+        .iter()
+        .flat_map(|(ps, pe)| t.iter().map(move |(ts, te)| overlap_ms(*ps, *pe, *ts, *te)))
+        .sum();
+    let pred_total: u64 = p.iter().map(|(s, e)| e.saturating_sub(*s)).sum();
+    let truth_total: u64 = t.iter().map(|(s, e)| e.saturating_sub(*s)).sum();
+    let union = pred_total + truth_total;
+    if union == 0 {
+        1.0
+    } else {
+        (2 * intersection) as f32 / union as f32
+    }
+}
+
+fn boundary_error(pred: &[Segment], truth: &[Segment]) -> f32 {
+    if pred.is_empty() || truth.is_empty() {
+        return 0.0;
+    }
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for p in pred {
+        if let Some(t) = truth.iter().min_by_key(|t| p.start_ms.abs_diff(t.start_ms)) {
+            total += p.start_ms.abs_diff(t.start_ms) + p.end_ms.abs_diff(t.end_ms);
+            count += 2;
+        }
+    }
+    if count == 0 {
+        0.0
+    } else {
+        total as f32 / count as f32
+    }
+}
+
+fn overlap_ms(a_start: u64, a_end: u64, b_start: u64, b_end: u64) -> u64 {
+    let start = a_start.max(b_start);
+    let end = a_end.min(b_end);
+    end.saturating_sub(start)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(start_ms: u64, end_ms: u64, kind: SegmentKind) -> Segment {
+        Segment {
+            start_ms,
+            end_ms,
+            kind,
+            confidence: 1.0,
+            tags: vec![],
+            prompt: None,
+        }
+    }
+
+    #[test]
+    fn metrics_are_stable() {
+        let pred = vec![
+            seg(0, 1000, SegmentKind::Speech),
+            seg(1000, 3000, SegmentKind::NonVoice),
+        ];
+        let truth = pred.clone();
+        let m = score_segments(&pred, &truth, 100);
+        assert_eq!(m.speech_precision, 1.0);
+        assert_eq!(m.non_voice_recall, 1.0);
+        assert!(m.overlap_ratio >= 0.99);
+    }
+}

--- a/src/validation/dataset.rs
+++ b/src/validation/dataset.rs
@@ -1,0 +1,36 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+
+use crate::validation::{speech_segment, timeline_from_speech_segments};
+
+pub fn build_truth_from_manifest(
+    manifest_csv: &Path,
+    media_name: &str,
+    total_ms: u64,
+    min_non_voice_ms: u32,
+) -> Result<crate::types::TimelineOutput> {
+    let data = fs::read_to_string(manifest_csv)
+        .with_context(|| format!("cannot read manifest {}", manifest_csv.display()))?;
+    let mut speech = Vec::new();
+    for (idx, line) in data.lines().enumerate() {
+        if idx == 0 && line.contains("start_ms") {
+            continue;
+        }
+        let cols: Vec<_> = line.split(',').collect();
+        if cols.len() < 2 {
+            continue;
+        }
+        let start_ms: u64 = cols[0].trim().parse().unwrap_or(0);
+        let end_ms: u64 = cols[1].trim().parse().unwrap_or(start_ms);
+        speech.push(speech_segment(start_ms, end_ms));
+    }
+    Ok(timeline_from_speech_segments(
+        media_name.to_string(),
+        16000,
+        20,
+        &speech,
+        total_ms,
+        min_non_voice_ms,
+    ))
+}

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -1,0 +1,94 @@
+pub mod compare;
+pub mod dataset;
+pub mod srt;
+pub mod synthetic;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::io::json::{read_timeline, write_json_pretty};
+use crate::pipeline::extract_timeline;
+use crate::types::{Segment, SegmentKind, TimelineOutput};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidationReport {
+    pub profile: String,
+    pub tolerance_ms: u64,
+    pub expected_segments: usize,
+    pub predicted_segments: usize,
+    pub overlap_ratio: f32,
+    pub boundary_error_ms: f32,
+    pub speech_precision: f32,
+    pub speech_recall: f32,
+    pub non_voice_precision: f32,
+    pub non_voice_recall: f32,
+}
+
+pub fn validate_against_timeline(
+    predicted: &TimelineOutput,
+    truth: &TimelineOutput,
+    profile: &str,
+    tolerance_ms: u64,
+) -> ValidationReport {
+    let metrics = compare::score_segments(&predicted.segments, &truth.segments, tolerance_ms);
+    ValidationReport {
+        profile: profile.to_string(),
+        tolerance_ms,
+        expected_segments: truth.segments.len(),
+        predicted_segments: predicted.segments.len(),
+        overlap_ratio: metrics.overlap_ratio,
+        boundary_error_ms: metrics.boundary_error_ms,
+        speech_precision: metrics.speech_precision,
+        speech_recall: metrics.speech_recall,
+        non_voice_precision: metrics.non_voice_precision,
+        non_voice_recall: metrics.non_voice_recall,
+    }
+}
+
+pub fn validate_file(
+    input_media: &Path,
+    truth_json: &Path,
+    output_report: &Path,
+    cfg: &crate::config::AnalysisConfig,
+    tolerance_ms: u64,
+    profile: &str,
+) -> Result<()> {
+    let predicted = extract_timeline(input_media, cfg)
+        .with_context(|| format!("extract failed for {}", input_media.display()))?;
+    let truth = read_timeline(truth_json)
+        .with_context(|| format!("cannot read truth json {}", truth_json.display()))?;
+    let report = validate_against_timeline(&predicted, &truth, profile, tolerance_ms);
+    write_json_pretty(output_report, &report)
+        .with_context(|| format!("cannot write {}", output_report.display()))?;
+    Ok(())
+}
+
+pub fn timeline_from_speech_segments(
+    file: String,
+    sample_rate: u32,
+    frame_ms: u32,
+    speech: &[Segment],
+    total_ms: u64,
+    min_non_voice_ms: u32,
+) -> TimelineOutput {
+    let non_voice =
+        crate::pipeline::segmenter::invert_to_non_voice(speech, total_ms, min_non_voice_ms);
+    TimelineOutput {
+        file,
+        analysis_sample_rate: sample_rate,
+        frame_ms,
+        segments: non_voice,
+    }
+}
+
+pub fn speech_segment(start_ms: u64, end_ms: u64) -> Segment {
+    Segment {
+        start_ms,
+        end_ms,
+        kind: SegmentKind::Speech,
+        confidence: 1.0,
+        tags: vec![],
+        prompt: None,
+    }
+}

--- a/src/validation/srt.rs
+++ b/src/validation/srt.rs
@@ -1,0 +1,64 @@
+use anyhow::{bail, Result};
+
+use crate::types::{Segment, SegmentKind};
+
+pub fn parse_srt_segments(input: &str) -> Result<Vec<Segment>> {
+    let mut speech = Vec::new();
+    for block in input.split("\n\n") {
+        let mut lines = block.lines().filter(|l| !l.trim().is_empty());
+        let Some(first) = lines.next() else { continue };
+        let time_line = if first.contains("-->") {
+            first
+        } else {
+            lines.next().unwrap_or_default()
+        };
+        if time_line.trim().is_empty() {
+            continue;
+        }
+        let Some((start, end)) = parse_time_span(time_line) else {
+            bail!("invalid srt timing line: {time_line}");
+        };
+        speech.push(Segment {
+            start_ms: start,
+            end_ms: end,
+            kind: SegmentKind::Speech,
+            confidence: 1.0,
+            tags: vec![],
+            prompt: None,
+        });
+    }
+    Ok(speech)
+}
+
+fn parse_time_span(line: &str) -> Option<(u64, u64)> {
+    let mut parts = line.split("-->");
+    let start = parse_stamp(parts.next()?.trim())?;
+    let end = parse_stamp(parts.next()?.trim())?;
+    Some((start, end))
+}
+
+fn parse_stamp(stamp: &str) -> Option<u64> {
+    let stamp = stamp.split_whitespace().next()?;
+    let mut parts = stamp.split(':');
+    let h: u64 = parts.next()?.parse().ok()?;
+    let m: u64 = parts.next()?.parse().ok()?;
+    let s_ms = parts.next()?;
+    let mut sec_parts = s_ms.split(',');
+    let s: u64 = sec_parts.next()?.parse().ok()?;
+    let ms: u64 = sec_parts.next()?.parse().ok()?;
+    Some((((h * 60 + m) * 60 + s) * 1000) + ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_srt() {
+        let srt =
+            "1\n00:00:00,000 --> 00:00:01,000\nHello\n\n2\n00:00:02,000 --> 00:00:03,000\nWorld\n";
+        let segs = parse_srt_segments(srt).unwrap_or_default();
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[1].start_ms, 2000);
+    }
+}

--- a/src/validation/synthetic.rs
+++ b/src/validation/synthetic.rs
@@ -1,0 +1,236 @@
+use anyhow::Result;
+use std::f32::consts::PI;
+use std::path::Path;
+
+use crate::io::json::write_json_pretty;
+use crate::types::{Segment, SegmentKind, TimelineOutput};
+
+const SR: u32 = 16_000;
+
+pub fn generate_suite(output_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(output_dir)?;
+    let cases = [
+        fixture_silence_only(),
+        fixture_speech_only(),
+        fixture_alternating(),
+        fixture_speech_noise(),
+        fixture_speech_music_like(),
+        fixture_impulse_heavy(),
+        fixture_short_bursts(),
+        fixture_long_ambience(),
+    ];
+
+    for case in cases {
+        let wav_path = output_dir.join(format!("{}.wav", case.name));
+        let json_path = output_dir.join(format!("{}.truth.json", case.name));
+        write_wav(&wav_path, &case.samples)?;
+        write_json_pretty(&json_path, &case.truth)?;
+    }
+    Ok(())
+}
+
+struct FixtureCase {
+    name: &'static str,
+    samples: Vec<f32>,
+    truth: TimelineOutput,
+}
+
+fn fixture_silence_only() -> FixtureCase {
+    let ms = 5_000;
+    let samples = vec![0.0; ms_to_len(ms)];
+    let truth = timeline(
+        "silence_only.wav",
+        vec![segment(0, ms as u64, SegmentKind::NonVoice)],
+    );
+    FixtureCase {
+        name: "silence_only",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_speech_only() -> FixtureCase {
+    let ms = 5_000;
+    let samples = tone(220.0, ms, 0.25);
+    let truth = timeline(
+        "speech_only.wav",
+        vec![segment(0, ms as u64, SegmentKind::Speech)],
+    );
+    FixtureCase {
+        name: "speech_only",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_alternating() -> FixtureCase {
+    let a = vec![0.0; ms_to_len(2_000)];
+    let b = tone(220.0, 2_200, 0.3);
+    let c = vec![0.0; ms_to_len(1_800)];
+    let mut samples = a;
+    samples.extend(b);
+    samples.extend(c);
+    let truth = timeline(
+        "alternating.wav",
+        vec![
+            segment(0, 2000, SegmentKind::NonVoice),
+            segment(2000, 4200, SegmentKind::Speech),
+            segment(4200, 6000, SegmentKind::NonVoice),
+        ],
+    );
+    FixtureCase {
+        name: "alternating",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_speech_noise() -> FixtureCase {
+    let mut samples = tone(250.0, 2_500, 0.22);
+    samples.extend(noise(2_500, 13));
+    let truth = timeline(
+        "speech_noise.wav",
+        vec![
+            segment(0, 2500, SegmentKind::Speech),
+            segment(2500, 5000, SegmentKind::NonVoice),
+        ],
+    );
+    FixtureCase {
+        name: "speech_noise",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_speech_music_like() -> FixtureCase {
+    let mut samples = tone(240.0, 2_500, 0.25);
+    samples.extend(music_like(2_500));
+    let truth = timeline(
+        "speech_music_like.wav",
+        vec![
+            segment(0, 2500, SegmentKind::Speech),
+            segment(2500, 5000, SegmentKind::NonVoice),
+        ],
+    );
+    FixtureCase {
+        name: "speech_music_like",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_impulse_heavy() -> FixtureCase {
+    let mut samples = vec![0.0; ms_to_len(5000)];
+    for idx in (0..samples.len()).step_by(1500) {
+        samples[idx] = 0.95;
+    }
+    let truth = timeline(
+        "impulse_heavy.wav",
+        vec![segment(0, 5000, SegmentKind::NonVoice)],
+    );
+    FixtureCase {
+        name: "impulse_heavy",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_short_bursts() -> FixtureCase {
+    let mut samples = vec![0.0; ms_to_len(5000)];
+    for start_ms in [800, 1600, 2500, 3300] {
+        let burst = tone(300.0, 120, 0.3);
+        let start = ms_to_len(start_ms);
+        let end = (start + burst.len()).min(samples.len());
+        samples[start..end].copy_from_slice(&burst[..(end - start)]);
+    }
+    let truth = timeline(
+        "short_bursts.wav",
+        vec![segment(0, 5000, SegmentKind::NonVoice)],
+    );
+    FixtureCase {
+        name: "short_bursts",
+        samples,
+        truth,
+    }
+}
+
+fn fixture_long_ambience() -> FixtureCase {
+    let samples = noise(12_000, 42).into_iter().map(|v| v * 0.02).collect();
+    let truth = timeline(
+        "long_ambience.wav",
+        vec![segment(0, 12_000, SegmentKind::NonVoice)],
+    );
+    FixtureCase {
+        name: "long_ambience",
+        samples,
+        truth,
+    }
+}
+
+fn timeline(file: &str, segments: Vec<Segment>) -> TimelineOutput {
+    TimelineOutput {
+        file: file.to_string(),
+        analysis_sample_rate: SR,
+        frame_ms: 20,
+        segments,
+    }
+}
+
+fn segment(start_ms: u64, end_ms: u64, kind: SegmentKind) -> Segment {
+    Segment {
+        start_ms,
+        end_ms,
+        kind,
+        confidence: 1.0,
+        tags: vec![],
+        prompt: None,
+    }
+}
+
+fn tone(freq: f32, dur_ms: usize, amp: f32) -> Vec<f32> {
+    (0..ms_to_len(dur_ms))
+        .map(|i| {
+            let t = i as f32 / SR as f32;
+            (2.0 * PI * freq * t).sin() * amp
+        })
+        .collect()
+}
+
+fn music_like(dur_ms: usize) -> Vec<f32> {
+    (0..ms_to_len(dur_ms))
+        .map(|i| {
+            let t = i as f32 / SR as f32;
+            ((2.0 * PI * 220.0 * t).sin() * 0.08) + ((2.0 * PI * 440.0 * t).sin() * 0.04)
+        })
+        .collect()
+}
+
+fn noise(dur_ms: usize, seed: u32) -> Vec<f32> {
+    let mut x = seed;
+    (0..ms_to_len(dur_ms))
+        .map(|_| {
+            x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+            ((x >> 8) as f32 / u32::MAX as f32 - 0.5) * 0.2
+        })
+        .collect()
+}
+
+fn ms_to_len(ms: usize) -> usize {
+    ms * SR as usize / 1000
+}
+
+fn write_wav(path: &Path, samples: &[f32]) -> Result<()> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: SR,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)?;
+    for s in samples {
+        let v = (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+        writer.write_sample(v)?;
+    }
+    writer.finalize()?;
+    Ok(())
+}

--- a/tests/tag_rules.rs
+++ b/tests/tag_rules.rs
@@ -3,6 +3,6 @@ use movie_nonvoice_timeline::pipeline::features::compute_features;
 #[test]
 fn feature_computation_is_deterministic() {
     let s = vec![0.0f32, 1.0, -1.0, 1.0, -1.0];
-    let f = compute_features(&s);
+    let f = compute_features(&s, 16_000);
     assert!(f.zcr > 0.0);
 }

--- a/tests/validation_cli.rs
+++ b/tests/validation_cli.rs
@@ -1,0 +1,81 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn generate_and_validate_synthetic_fixture() {
+    let d = tempdir().unwrap_or_else(|_| panic!("tmpdir"));
+    let fixtures = d.path().join("fixtures");
+    Command::cargo_bin("timeline")
+        .unwrap_or_else(|_| panic!("bin"))
+        .args([
+            "gen-fixtures",
+            "--output-dir",
+            fixtures.to_str().unwrap_or_default(),
+        ])
+        .assert()
+        .success();
+
+    let wav = fixtures.join("alternating.wav");
+    let truth = fixtures.join("alternating.truth.json");
+    let report = d.path().join("report.json");
+
+    Command::cargo_bin("timeline")
+        .unwrap_or_else(|_| panic!("bin"))
+        .args([
+            "validate",
+            wav.to_str().unwrap_or_default(),
+            "--truth-json",
+            truth.to_str().unwrap_or_default(),
+            "--profile",
+            "synthetic",
+            "--output",
+            report.to_str().unwrap_or_default(),
+        ])
+        .assert()
+        .success();
+
+    assert!(report.exists());
+}
+
+#[test]
+fn validate_with_subtitles() {
+    let d = tempdir().unwrap_or_else(|_| panic!("tmpdir"));
+    let wav = d.path().join("in.wav");
+    let srt = d.path().join("a.srt");
+    let report = d.path().join("report.json");
+
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: 16000,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(&wav, spec).unwrap_or_else(|_| panic!("wav"));
+    for _ in 0..16000 {
+        writer.write_sample(0i16).unwrap_or_default();
+    }
+    writer.finalize().unwrap_or_default();
+
+    std::fs::write(
+        &srt,
+        "1\n00:00:00,100 --> 00:00:00,300\nhello\n\n2\n00:00:00,400 --> 00:00:00,600\nworld\n",
+    )
+    .unwrap_or_default();
+
+    Command::cargo_bin("timeline")
+        .unwrap_or_else(|_| panic!("bin"))
+        .args([
+            "validate",
+            wav.to_str().unwrap_or_default(),
+            "--subtitles",
+            srt.to_str().unwrap_or_default(),
+            "--total-ms",
+            "1000",
+            "--output",
+            report.to_str().unwrap_or_default(),
+        ])
+        .assert()
+        .success();
+
+    assert!(report.exists());
+}


### PR DESCRIPTION
### Motivation
- Complete and harden the extraction pipeline to support deterministic validation across synthetic, dataset and movie/subtitle sources. 
- Provide deterministic fixtures and a validation engine so non-voice extraction can be measured with repeatable metrics and tolerances. 
- Improve tagging and prompt generation to produce deterministic, listener-safe prompts and richer acoustic tags. 
- Add logging and pipeline stability fixes to make the CLI production-ready for benchmarking and CI quality gates. 

### Description
- Added a `validation` subsystem including `compare`, `synthetic`, `srt`, and `dataset` modules and `ValidationReport` types to score timelines and produce reports. 
- Added CLI commands `gen-fixtures` and `validate` (and wiring in `src/cli.rs` / `src/main.rs`) to generate deterministic synthetic WAV + truth JSON fixtures and validate using truth JSON, `.srt`, or dataset CSV manifests. 
- Hardened pipeline with stage logging in `pipeline::extract_timeline`, merged nearby speech segments via `merge_close_segments`, and reduced single-frame flicker in `segmenter::smooth_speech`. 
- Expanded feature extraction in `pipeline::features` with spectral flux, centroid, and band ratios and richer tag mapping in `pipeline::tags`, and updated deterministic prompt selection in `pipeline::prompts`. 
- Added synthetic fixture generator `validation::synthetic::generate_suite` producing multiple deterministic cases and dataset/SRT adapters that convert timestamps into speech timelines then invert to non-voice truth. 
- Minor API/IO utilities added: `validation::timeline_from_speech_segments`, `validation::speech_segment`, and test helpers; read/write JSON utilities reused for reports. 

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy --all-targets --all-features -- -D warnings` which succeeded. 
- Ran the full test suite with `cargo test` and all automated tests passed. 
- Ran the repository quality gate via `bash scripts/quality_gate.sh`, generated fixtures with `cargo run -- gen-fixtures`, and executed the benchmark smoke via `bash scripts/benchmark.sh testdata/generated/alternating.wav`, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce6dd3250832b85995d9119dcce49)