### PR TITLE
Harden benchmark workflow with automatic fixture generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ testdata/raw/*
 !testdata/raw/.gitkeep
 testdata/generated/*.wav
 *.tmp
+testdata/generated/*
+!testdata/generated/.gitkeep

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -3,5 +3,11 @@ set -euo pipefail
 input=${1:-testdata/generated/alternating.wav}
 out=${2:-analysis/benchmarks/latest.json}
 mkdir -p "$(dirname "$out")"
+
+if [[ ! -f "$input" ]]; then
+  echo "benchmark input missing ($input); generating deterministic fixtures..." >&2
+  cargo run --quiet -- gen-fixtures --output-dir testdata/generated
+fi
+
 cargo run --quiet -- bench "$input" --output "$out"
 echo "benchmark written: $out"


### PR DESCRIPTION
### Motivation
- Make the benchmark helper robust on fresh checkouts by automatically generating deterministic fixtures when the expected benchmark input is missing so CI and local runs don't fail.

### Description
- Modify `scripts/benchmark.sh` to create the output directory, detect a missing input and run `cargo run -- gen-fixtures --output-dir testdata/generated` before invoking the bench command, and add a tracked `.gitkeep` plus updated `.gitignore` entries so `testdata/generated/` remains a tracked directory while generated artifacts stay ignored.

### Testing
- Executed `bash scripts/quality_gate.sh` (runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`) and `bash scripts/benchmark.sh testdata/generated/alternating.wav`, and all unit/integration tests passed and the benchmark completed successfully writing `analysis/benchmarks/latest.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd171736ac832b9eeec8ce301233e3)