### PR TITLE
Branching audio decode with Symphonia and FFmpeg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +363,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -726,6 +738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +761,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fallible-iterator"
@@ -1875,6 +1902,7 @@ dependencies = [
  "realfft",
  "serde",
  "serde_json",
+ "symphonia",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2877,6 +2905,152 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ hound = "3"
 realfft = "3"
 tempfile = "3"
 libsql = "0.9"
+symphonia = { version = "0.5", features = ["mp3", "wav", "flac", "ogg", "pcm"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ timelines, which can be exported to EDL or VTT formats.
 
 ## Prerequisites
 - Rust 1.75+ (2021 edition)
-- ffmpeg (must be on PATH for processing non-WAV media)
+- ffmpeg (optional; required only for video container inputs such as MKV, MP4, AVI)
 
 ## Build
 ```bash

--- a/benches/pipeline_bench.rs
+++ b/benches/pipeline_bench.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use movie_nonvoice_timeline::pipeline::{
     decode,
     features::compute_features,
-    framing, resample, segmenter,
+    framing, segmenter,
     vad::{EnergyVad, VadEngine},
 };
 use std::{hint::black_box, path::Path, sync::OnceLock, time::Duration};
@@ -47,11 +47,10 @@ fn load_bench_samples() -> Vec<f32> {
         return sample_audio();
     };
 
-    let Ok((samples, source_rate)) = decode::decode_audio(Path::new(path)) else {
+    let Ok((mut mono, _source_rate)) = decode::decode_audio(Path::new(path), BENCH_SAMPLE_RATE_HZ)
+    else {
         return sample_audio();
     };
-
-    let mut mono = resample::resample_linear(&samples, source_rate, BENCH_SAMPLE_RATE_HZ);
     mono.truncate(mono.len().min(MAX_BENCH_SAMPLES));
     if mono.is_empty() {
         sample_audio()

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -208,4 +208,46 @@ mod tests {
         assert_eq!(sr, 8000); // Now always returns target rate
         assert_eq!(samples.len(), 8000);
     }
+
+    #[test]
+    fn test_decode_via_symphonia_stereo() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let wav_path = temp_dir.path().join("stereo.wav");
+
+        // Create a 1 second stereo WAV file with 1.0 in left and -1.0 in right
+        // Downmix should be (1.0 + -1.0) / 2 = 0.0
+        let spec = WavSpec {
+            channels: 2,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&wav_path, spec).unwrap();
+        for _ in 0..16000 {
+            writer.write_sample(i16::MAX).unwrap();
+            writer.write_sample(i16::MIN + 1).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let (samples, _) = decode_via_symphonia(&wav_path, Some("wav"), 16000).unwrap();
+        assert_eq!(samples.len(), 16000);
+        for &s in &samples {
+            assert!(s.abs() < 1e-4);
+        }
+    }
+
+    #[test]
+    fn test_decode_audio_dispatch_ffmpeg() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mp4_path = temp_dir.path().join("test.mp4");
+        std::fs::write(&mp4_path, b"dummy content").unwrap();
+
+        // Should NOT call symphonia because of .mp4 extension
+        // Should attempt ffmpeg and fail because it's not a real mp4
+        let res = decode_audio(&mp4_path, 16000);
+        assert!(res.is_err());
+        let err = res.unwrap_err().to_string();
+        // ffmpeg error or "failed to execute ffmpeg" if not installed
+        assert!(err.contains("ffmpeg") || err.contains("No such file"));
+    }
 }

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -17,11 +17,15 @@ pub fn decode_audio(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u
     }
 
     let ext = path.extension().and_then(|e| e.to_str());
-    if matches!(ext, Some("mp3" | "wav" | "flac" | "ogg")) {
-        match decode_via_symphonia(path, target_sample_rate) {
-            Ok((samples, sr)) => return Ok((samples, sr)),
-            Err(err) => {
-                info!(input = %path.display(), error = %err, "symphonia decode failed, falling back to ffmpeg");
+    let ext_lower = ext.map(|s| s.to_lowercase());
+
+    if let Some(ext_str) = ext_lower.as_deref() {
+        if matches!(ext_str, "mp3" | "wav" | "flac" | "ogg") {
+            match decode_via_symphonia(path, ext, target_sample_rate) {
+                Ok((samples, sr)) => return Ok((samples, sr)),
+                Err(err) => {
+                    info!(input = %path.display(), error = %err, "symphonia decode failed, falling back to ffmpeg");
+                }
             }
         }
     }
@@ -29,11 +33,15 @@ pub fn decode_audio(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u
     decode_via_ffmpeg(path, target_sample_rate)
 }
 
-fn decode_via_symphonia(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u32)> {
+fn decode_via_symphonia(
+    path: &Path,
+    extension: Option<&str>,
+    target_sample_rate: u32,
+) -> Result<(Vec<f32>, u32)> {
     let file = std::fs::File::open(path)?;
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
     let mut hint = Hint::new();
-    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+    if let Some(ext) = extension {
         hint.with_extension(ext);
     }
 
@@ -161,12 +169,19 @@ mod tests {
         let wav_path = temp_dir.path().join("test.wav");
 
         // Create a 1 second silence WAV file
-    fn create_test_wav(path: &std::path::Path, sample_rate: u32) {
-        let spec = hound::WavSpec { channels: 1, sample_rate, bits_per_sample: 16, sample_format: hound::SampleFormat::Int };
-        let mut writer = hound::WavWriter::create(path, spec).unwrap();
-        for _ in 0..sample_rate { writer.write_sample(0i16).unwrap(); }
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&wav_path, spec).unwrap();
+        for _ in 0..16000 {
+            writer.write_sample(0i16).unwrap();
+        }
         writer.finalize().unwrap();
-    }
+
+        let (samples, _) = decode_via_symphonia(&wav_path, Some("wav"), 16000).unwrap();
         assert_eq!(samples.len(), 16000);
         for &s in &samples {
             assert_eq!(s, 0.0);
@@ -190,7 +205,7 @@ mod tests {
         writer.finalize().unwrap();
 
         let (samples, sr) = decode_audio(&wav_path, 8000).unwrap();
-        assert_eq!(sr, 8000); // Should match the rate of the returned samples
+        assert_eq!(sr, 8000); // Now always returns target rate
         assert_eq!(samples.len(), 8000);
     }
 }

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -103,7 +103,7 @@ fn decode_via_symphonia(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32
         source_sample_rate,
         target_sample_rate,
     );
-    Ok((resampled, source_sample_rate))
+    Ok((resampled, target_sample_rate))
 }
 
 fn decode_via_ffmpeg(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u32)> {

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -197,7 +197,7 @@ mod tests {
         writer.finalize().unwrap();
 
         let (samples, sr) = decode_audio(&wav_path, 8000).unwrap();
-        assert_eq!(sr, 16000); // Original source rate
+        assert_eq!(sr, 8000); // Should match the rate of the returned samples
         assert_eq!(samples.len(), 8000);
     }
 }

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -161,19 +161,12 @@ mod tests {
         let wav_path = temp_dir.path().join("test.wav");
 
         // Create a 1 second silence WAV file
-        let spec = WavSpec {
-            channels: 1,
-            sample_rate: 16000,
-            bits_per_sample: 16,
-            sample_format: hound::SampleFormat::Int,
-        };
-        let mut writer = WavWriter::create(&wav_path, spec).unwrap();
-        for _ in 0..16000 {
-            writer.write_sample(0i16).unwrap();
-        }
+    fn create_test_wav(path: &std::path::Path, sample_rate: u32) {
+        let spec = hound::WavSpec { channels: 1, sample_rate, bits_per_sample: 16, sample_format: hound::SampleFormat::Int };
+        let mut writer = hound::WavWriter::create(path, spec).unwrap();
+        for _ in 0..sample_rate { writer.write_sample(0i16).unwrap(); }
         writer.finalize().unwrap();
-
-        let (samples, _) = decode_via_symphonia(&wav_path, 16000).unwrap();
+    }
         assert_eq!(samples.len(), 16000);
         for &s in &samples {
             assert_eq!(s, 0.0);

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -247,7 +247,14 @@ mod tests {
         let res = decode_audio(&mp4_path, 16000);
         assert!(res.is_err());
         let err = res.unwrap_err().to_string();
-        // ffmpeg error or "failed to execute ffmpeg" if not installed
-        assert!(err.contains("ffmpeg") || err.contains("No such file"));
+        // Should fail because it's not a real mp4.
+        // We expect either an execution error or a decode error from ffmpeg.
+        assert!(
+            err.contains("ffmpeg")
+                || err.contains("No such file")
+                || err.contains("decode failure"),
+            "Error should be related to ffmpeg or decode failure, got: {}",
+            err
+        );
     }
 }

--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -1,32 +1,112 @@
 use anyhow::{bail, Context, Result};
 use std::{path::Path, process::Command};
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::DecoderOptions;
+use symphonia::core::errors::Error;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
 use tracing::info;
 
 use crate::error::TimelineError;
-use crate::io::wav::read_wav_to_f32;
 
-pub fn decode_audio(path: &Path) -> Result<(Vec<f32>, u32)> {
+pub fn decode_audio(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u32)> {
     if !path.exists() {
         return Err(TimelineError::MissingInput(path.display().to_string()).into());
     }
-    if path.extension().and_then(|e| e.to_str()) == Some("wav") {
-        match read_wav_to_f32(path) {
-            Ok((samples, sr)) => {
-                if samples.is_empty() {
-                    return Err(TimelineError::EmptyAudio.into());
-                }
-                return Ok((samples, sr));
-            }
+
+    let ext = path.extension().and_then(|e| e.to_str());
+    if matches!(ext, Some("mp3" | "wav" | "flac" | "ogg")) {
+        match decode_via_symphonia(path, target_sample_rate) {
+            Ok((samples, sr)) => return Ok((samples, sr)),
             Err(err) => {
-                info!(input = %path.display(), error = %err, "direct wav decode failed, falling back to ffmpeg");
+                info!(input = %path.display(), error = %err, "symphonia decode failed, falling back to ffmpeg");
             }
         }
     }
 
-    decode_with_ffmpeg(path)
+    decode_via_ffmpeg(path, target_sample_rate)
 }
 
-fn decode_with_ffmpeg(path: &Path) -> Result<(Vec<f32>, u32)> {
+fn decode_via_symphonia(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u32)> {
+    let file = std::fs::File::open(path)?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    let probed = symphonia::default::get_probe().format(
+        &hint,
+        mss,
+        &FormatOptions::default(),
+        &MetadataOptions::default(),
+    )?;
+
+    let mut format = probed.format;
+    let track = format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != symphonia::core::codecs::CODEC_TYPE_NULL)
+        .context("no audio track found")?;
+
+    let mut decoder =
+        symphonia::default::get_codecs().make(&track.codec_params, &DecoderOptions::default())?;
+
+    let track_id = track.id;
+    let source_sample_rate = track
+        .codec_params
+        .sample_rate
+        .context("unknown sample rate")?;
+
+    let mut samples = Vec::new();
+    let mut sample_buf = None;
+
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(Error::IoError(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e.into()),
+        };
+
+        if packet.track_id() != track_id {
+            continue;
+        }
+
+        let decoded = decoder.decode(&packet)?;
+
+        if sample_buf.is_none() {
+            let spec = *decoded.spec();
+            let duration = decoded.capacity() as u64;
+            sample_buf = Some(SampleBuffer::<f32>::new(duration, spec));
+        }
+
+        let frames = decoded.frames();
+        let channels = decoded.spec().channels.count();
+
+        let buf = sample_buf.as_mut().unwrap();
+        buf.copy_interleaved_ref(decoded);
+
+        for frame in buf.samples()[..frames * channels].chunks_exact(channels) {
+            let mono_sample: f32 = frame.iter().sum::<f32>() / channels as f32;
+            samples.push(mono_sample);
+        }
+    }
+
+    if samples.is_empty() {
+        return Err(TimelineError::EmptyAudio.into());
+    }
+
+    let resampled = crate::pipeline::resample::resample_linear(
+        &samples,
+        source_sample_rate,
+        target_sample_rate,
+    );
+    Ok((resampled, source_sample_rate))
+}
+
+fn decode_via_ffmpeg(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u32)> {
     let output = Command::new("ffmpeg")
         .args([
             "-hide_banner",
@@ -38,7 +118,7 @@ fn decode_with_ffmpeg(path: &Path) -> Result<(Vec<f32>, u32)> {
             "-ac",
             "1",
             "-ar",
-            "16000",
+            &target_sample_rate.to_string(),
             "-f",
             "s16le",
             "-",
@@ -63,5 +143,61 @@ fn decode_with_ffmpeg(path: &Path) -> Result<(Vec<f32>, u32)> {
         let s = i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32;
         samples.push(s);
     }
-    Ok((samples, 16000))
+    // ffmpeg can return the actual source sample rate if we probed it, but here we assume it worked
+    // as requested. To get the TRUE source rate we'd need a separate ffprobe call or parse stderr.
+    // For now we'll return target_sample_rate as a best-effort if we can't easily get the original.
+    // However, the pipeline might want to know if it was 44100 or 48000.
+    Ok((samples, target_sample_rate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::{WavSpec, WavWriter};
+
+    #[test]
+    fn test_decode_via_symphonia_wav() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let wav_path = temp_dir.path().join("test.wav");
+
+        // Create a 1 second silence WAV file
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&wav_path, spec).unwrap();
+        for _ in 0..16000 {
+            writer.write_sample(0i16).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let (samples, _) = decode_via_symphonia(&wav_path, 16000).unwrap();
+        assert_eq!(samples.len(), 16000);
+        for &s in &samples {
+            assert_eq!(s, 0.0);
+        }
+    }
+
+    #[test]
+    fn test_decode_audio_dispatch() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let wav_path = temp_dir.path().join("test.wav");
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&wav_path, spec).unwrap();
+        for _ in 0..16000 {
+            writer.write_sample(0i16).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let (samples, sr) = decode_audio(&wav_path, 8000).unwrap();
+        assert_eq!(sr, 16000); // Original source rate
+        assert_eq!(samples.len(), 8000);
+    }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -61,26 +61,17 @@ fn run_pipeline(input: &Path, cfg: &AnalysisConfig) -> Result<PipelineArtifacts>
     let mut stage_ms = StageDurations::default();
 
     let decode_start = Instant::now();
-    let (samples, source_rate) = decode::decode_audio(input)?;
+    let (mono, source_rate) = decode::decode_audio(input, cfg.sample_rate_hz)?;
     stage_ms.decode_ms = decode_start.elapsed().as_millis();
     info!(
         stage = "decode",
         ms = stage_ms.decode_ms,
         source_rate,
-        samples = samples.len(),
-        "stage complete"
-    );
-
-    let resample_start = Instant::now();
-    let mono = resample::resample_linear(&samples, source_rate, cfg.sample_rate_hz);
-    stage_ms.resample_ms = resample_start.elapsed().as_millis();
-    info!(
-        stage = "resample",
-        ms = stage_ms.resample_ms,
-        target_rate = cfg.sample_rate_hz,
         samples = mono.len(),
         "stage complete"
     );
+
+    stage_ms.resample_ms = 0; // Resampling is now integrated into decode
 
     let frame_start = Instant::now();
     let frames = framing::build_frames(&mono, cfg.sample_rate_hz, cfg.frame_ms);

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -487,3 +487,36 @@ mod tests {
         assert!(!should_apply_speech_evidence_filter(&cfg));
     }
 }
+
+#[cfg(test)]
+mod pipeline_tests {
+    use super::*;
+    use crate::config::AnalysisConfig;
+    use hound::{WavSpec, WavWriter};
+
+    #[test]
+    fn test_run_pipeline_smoke() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let wav_path = temp_dir.path().join("test.wav");
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = WavWriter::create(&wav_path, spec).unwrap();
+        // 1 second of silence
+        for _ in 0..16000 {
+            writer.write_sample(0i16).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        let cfg = AnalysisConfig {
+            min_non_voice_ms: 100, // Small enough to detect silence in 1s
+            ..AnalysisConfig::default()
+        };
+        let result = run_pipeline(&wav_path, &cfg).unwrap();
+        assert!(!result.timeline.segments.is_empty());
+        assert_eq!(result.timeline.analysis_sample_rate, 16000);
+    }
+}

--- a/src/pipeline/tags.rs
+++ b/src/pipeline/tags.rs
@@ -7,6 +7,7 @@ use crate::types::{SegmentKind, TimelineOutput};
 
 pub fn add_tags(input_media: &Path, timeline: &mut TimelineOutput) -> Result<()> {
     let (samples, sr) = decode::decode_audio(input_media, timeline.analysis_sample_rate)?;
+    let mut extractor = FeatureExtractor::new(1024);
     for seg in &mut timeline.segments {
         if seg.kind != SegmentKind::NonVoice {
             continue;

--- a/src/pipeline/tags.rs
+++ b/src/pipeline/tags.rs
@@ -76,4 +76,41 @@ mod tests {
         };
         assert!(map_tags(f).contains(&"ambience".to_string()));
     }
+
+    #[test]
+    fn test_add_tags_indexing_safety() {
+        use crate::types::Segment;
+        let mut timeline = TimelineOutput {
+            file: "test".into(),
+            analysis_sample_rate: 16000,
+            frame_ms: 20,
+            segments: vec![Segment {
+                start_ms: 0,
+                end_ms: 2000, // 2 seconds
+                kind: SegmentKind::NonVoice,
+                confidence: 1.0,
+                tags: vec![],
+                prompt: None,
+            }],
+        };
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let wav_path = temp_dir.path().join("short.wav");
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(&wav_path, spec).unwrap();
+        // Only 1 second of audio
+        for _ in 0..16000 {
+            writer.write_sample(0i16).unwrap();
+        }
+        writer.finalize().unwrap();
+
+        // Should not panic even though segment (2s) > audio (1s)
+        add_tags(&wav_path, &mut timeline).unwrap();
+        assert!(!timeline.segments[0].tags.is_empty());
+    }
 }

--- a/src/pipeline/tags.rs
+++ b/src/pipeline/tags.rs
@@ -14,7 +14,11 @@ pub fn add_tags(input_media: &Path, timeline: &mut TimelineOutput) -> Result<()>
         }
         let start = (seg.start_ms * sr as u64 / 1000) as usize;
         let end = (seg.end_ms * sr as u64 / 1000) as usize;
-        let clip = &samples[start.min(samples.len())..end.min(samples.len())];
+
+        let start = start.min(samples.len());
+        let end = end.clamp(start, samples.len());
+
+        let clip = &samples[start..end];
         let f = extractor.extract(clip, sr);
         seg.tags = map_tags(f);
     }
@@ -112,5 +116,11 @@ mod tests {
         // Should not panic even though segment (2s) > audio (1s)
         add_tags(&wav_path, &mut timeline).unwrap();
         assert!(!timeline.segments[0].tags.is_empty());
+
+        // Test with start > end (should be clamped and empty clip)
+        timeline.segments[0].start_ms = 3000;
+        timeline.segments[0].end_ms = 2000;
+        add_tags(&wav_path, &mut timeline).unwrap();
+        assert!(timeline.segments[0].tags.contains(&"ambience".to_string()));
     }
 }

--- a/src/pipeline/tags.rs
+++ b/src/pipeline/tags.rs
@@ -6,7 +6,7 @@ use crate::pipeline::features::compute_features;
 use crate::types::{SegmentKind, TimelineOutput};
 
 pub fn add_tags(input_media: &Path, timeline: &mut TimelineOutput) -> Result<()> {
-    let (samples, sr) = decode::decode_audio(input_media)?;
+    let (samples, sr) = decode::decode_audio(input_media, timeline.analysis_sample_rate)?;
     for seg in &mut timeline.segments {
         if seg.kind != SegmentKind::NonVoice {
             continue;


### PR DESCRIPTION
Implement a branching strategy for audio decoding in `src/pipeline/decode.rs`. Use the `symphonia` crate to natively decode pure audio files (.mp3, .wav, .flac, .ogg) in Rust, while retaining `ffmpeg` as a demuxer for video containers (MKV, MP4, AVI). This change reduces the hard requirement for `ffmpeg` for users only processing pure audio files and reduces subprocess overhead. The implementation includes integrated resampling and downmixing to mono. All call sites in the pipeline, tagging, and benchmarks have been updated to support the new decoding flow. Unit tests and documentation updates are included.

Fixes #25

---
*PR created automatically by Jules for task [15338150578429889617](https://jules.google.com/task/15338150578429889617) started by @d-oit*