### PR TITLE
bench(vad): add SpectralVad and HybridVad to pipeline benchmarks

### DIFF
--- a/benches/pipeline_bench.rs
+++ b/benches/pipeline_bench.rs
@@ -3,7 +3,7 @@ use movie_nonvoice_timeline::pipeline::{
     decode,
     features::compute_features,
     framing, segmenter,
-    vad::{EnergyVad, VadEngine},
+    vad::{EnergyVad, HybridVad, SpectralVad, VadEngine},
 };
 use std::{hint::black_box, path::Path, sync::OnceLock, time::Duration};
 
@@ -99,9 +99,19 @@ fn bench_features(c: &mut Criterion) {
 fn bench_vad(c: &mut Criterion) {
     let frames =
         framing::build_frames(bench_samples(), BENCH_SAMPLE_RATE_HZ, BENCH_FRAME_MS, false);
-    let vad = EnergyVad::new(0.015);
+    let energy_vad = EnergyVad::new(0.015);
     c.bench_function("energy_vad", |b| {
-        b.iter(|| vad.classify(black_box(&frames)))
+        b.iter(|| energy_vad.classify(black_box(&frames)))
+    });
+
+    let spectral_vad = SpectralVad::new(0.015);
+    c.bench_function("spectral_vad", |b| {
+        b.iter(|| spectral_vad.classify(black_box(&frames)))
+    });
+
+    let hybrid_vad = HybridVad::new(0.015);
+    c.bench_function("hybrid_vad", |b| {
+        b.iter(|| hybrid_vad.classify(black_box(&frames)))
     });
 }
 


### PR DESCRIPTION
## Summary

Adds SpectralVad and HybridVad to the existing Criterion benchmark suite.

## Changes

- Import `SpectralVad` and `HybridVad` in `benches/pipeline_bench.rs`
- Add `spectral_vad` and `hybrid_vad` benchmark functions alongside existing `energy_vad`
- All three engines benchmark identical frame data for fair comparison

## Benchmark Results

| Engine | Time (µs) |
|--------|-----------|
| EnergyVad | 33.2 µs |
| SpectralVad | 49.1 µs |
| HybridVad | 83.1 µs |

## Verification

- `cargo bench --bench pipeline_bench -- --quick` runs successfully
- `cargo fmt --check` passes
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- All existing tests pass

Closes #56