### PR TITLE
feat: implement profile-driven tag calibration (Phase 6.1 initial slice)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,8 @@ pub enum Commands {
         input: PathBuf,
         #[arg(long)]
         output: PathBuf,
+        #[arg(long)]
+        calibration_profile: Option<PathBuf>,
     },
     Prompt {
         input_json: PathBuf,

--- a/src/learning/calibrator.rs
+++ b/src/learning/calibrator.rs
@@ -76,6 +76,7 @@ pub fn apply_calibration_report(report_path: &Path, output_profile: &Path) -> Re
         name: format!("{}-v{}", report.profile, report.version + 1),
         energy_threshold_delta: report.recommended_energy_threshold_delta,
         version: report.version + 1,
+        tag_thresholds: None,
     };
     if let Some(parent) = output_profile.parent() {
         fs::create_dir_all(parent)?;

--- a/src/learning/profiles.rs
+++ b/src/learning/profiles.rs
@@ -4,12 +4,28 @@ fn default_version() -> u32 {
     1
 }
 
+fn default_tag_delta() -> f32 {
+    0.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagThresholds {
+    #[serde(default = "default_tag_delta")]
+    pub ambience_max_rms_delta: f32,
+    #[serde(default = "default_tag_delta")]
+    pub impact_min_rms_delta: f32,
+    #[serde(default = "default_tag_delta")]
+    pub min_centroid_hz_delta: f32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalibrationProfile {
     pub name: String,
     pub energy_threshold_delta: f32,
     #[serde(default = "default_version")]
     pub version: u32,
+    #[serde(default)]
+    pub tag_thresholds: Option<TagThresholds>,
 }
 
 pub fn profile(name: &str) -> CalibrationProfile {
@@ -18,21 +34,25 @@ pub fn profile(name: &str) -> CalibrationProfile {
             name: name.to_string(),
             energy_threshold_delta: 0.01,
             version: 1,
+            tag_thresholds: None,
         },
         "documentary" => CalibrationProfile {
             name: name.to_string(),
             energy_threshold_delta: -0.003,
             version: 1,
+            tag_thresholds: None,
         },
         "animation" => CalibrationProfile {
             name: name.to_string(),
             energy_threshold_delta: 0.0,
             version: 1,
+            tag_thresholds: None,
         },
         _ => CalibrationProfile {
             name: "drama".to_string(),
             energy_threshold_delta: -0.001,
             version: 1,
+            tag_thresholds: None,
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use crate::io::json::{read_json, read_timeline, write_json_pretty};
 use crate::learning::calibrator::{apply_calibration_report, run_calibration};
 use crate::learning::profiles::CalibrationProfile;
 use crate::pipeline::prompts::add_prompts;
-use crate::pipeline::tags::add_tags;
+use crate::pipeline::tags::{add_tags, TagRules};
 use crate::pipeline::{benchmark_file, extract_timeline};
 
 fn main() {
@@ -82,6 +82,7 @@ fn run() -> Result<()> {
                     name: "runtime".to_string(),
                     energy_threshold_delta: cfg.vad_threshold_delta,
                     version: 1,
+                    tag_thresholds: None,
                 };
                 if let Some(parent) = profile_path.parent() {
                     std::fs::create_dir_all(parent)?;
@@ -94,9 +95,11 @@ fn run() -> Result<()> {
             input_media,
             input,
             output,
+            calibration_profile,
         } => {
             let mut timeline = read_timeline(&input)?;
-            add_tags(&input_media, &mut timeline)?;
+            let rules = load_tag_rules(calibration_profile.as_deref())?;
+            add_tags(&input_media, &mut timeline, rules.as_ref())?;
             write_json_pretty(&output, &timeline)?;
         }
         Commands::Prompt {
@@ -632,6 +635,34 @@ fn load_calibration_threshold_delta(profile_path: Option<&std::path::Path>) -> R
     })?;
     info!(profile = %profile.name, delta = profile.energy_threshold_delta, "loaded calibration profile");
     Ok(Some(profile.energy_threshold_delta))
+}
+
+fn load_tag_rules(profile_path: Option<&std::path::Path>) -> Result<Option<TagRules>> {
+    let Some(profile_path) = profile_path else {
+        return Ok(None);
+    };
+    let profile: CalibrationProfile = read_json(profile_path).with_context(|| {
+        format!(
+            "failed to read calibration profile: {}",
+            profile_path.display()
+        )
+    })?;
+    let rules = profile
+        .tag_thresholds
+        .as_ref()
+        .map(TagRules::from_thresholds);
+    if let Some(rules) = &rules {
+        info!(
+            profile = %profile.name,
+            ambience_max_rms = rules.ambience_max_rms,
+            impact_min_rms = rules.impact_min_rms,
+            min_centroid_hz = rules.min_centroid_hz,
+            "loaded tag rules from calibration profile"
+        );
+    } else {
+        info!(profile = %profile.name, "profile has no tag thresholds, using defaults");
+    }
+    Ok(rules)
 }
 
 fn load_merge_options(

--- a/src/pipeline/tags.rs
+++ b/src/pipeline/tags.rs
@@ -1,11 +1,45 @@
 use anyhow::Result;
 use std::path::Path;
 
+use crate::learning::profiles::TagThresholds;
 use crate::pipeline::decode;
 use crate::pipeline::features::FeatureExtractor;
 use crate::types::{SegmentKind, TimelineOutput};
 
-pub fn add_tags(input_media: &Path, timeline: &mut TimelineOutput) -> Result<()> {
+#[derive(Debug, Clone)]
+pub struct TagRules {
+    pub ambience_max_rms: f32,
+    pub impact_min_rms: f32,
+    pub min_centroid_hz: f32,
+}
+
+impl Default for TagRules {
+    fn default() -> Self {
+        Self {
+            ambience_max_rms: 0.012,
+            impact_min_rms: 0.05,
+            min_centroid_hz: 1800.0,
+        }
+    }
+}
+
+impl TagRules {
+    pub fn from_thresholds(thresholds: &TagThresholds) -> Self {
+        Self {
+            ambience_max_rms: (0.012 + thresholds.ambience_max_rms_delta).max(0.002),
+            impact_min_rms: (0.05 + thresholds.impact_min_rms_delta).max(0.01),
+            min_centroid_hz: (1800.0 + thresholds.min_centroid_hz_delta).max(100.0),
+        }
+    }
+}
+
+pub fn add_tags(
+    input_media: &Path,
+    timeline: &mut TimelineOutput,
+    rules: Option<&TagRules>,
+) -> Result<()> {
+    let default_rules = TagRules::default();
+    let rules = rules.unwrap_or(&default_rules);
     let (samples, sr) = decode::decode_audio(input_media, timeline.analysis_sample_rate)?;
     let mut extractor = FeatureExtractor::new(1024);
     for seg in &mut timeline.segments {
@@ -20,23 +54,23 @@ pub fn add_tags(input_media: &Path, timeline: &mut TimelineOutput) -> Result<()>
 
         let clip = &samples[start..end];
         let f = extractor.extract(clip, sr);
-        seg.tags = map_tags(f);
+        seg.tags = map_tags(f, rules);
     }
     Ok(())
 }
 
-fn map_tags(f: crate::pipeline::features::FeatureSet) -> Vec<String> {
+fn map_tags(f: crate::pipeline::features::FeatureSet, rules: &TagRules) -> Vec<String> {
     let mut tags = Vec::new();
-    if f.rms < 0.012 {
+    if f.rms < rules.ambience_max_rms {
         tags.push("ambience".into());
     }
     if f.low_band_ratio > 0.25 && f.rms > 0.015 {
         tags.push("music_bed".into());
     }
-    if f.spectral_flux > 0.01 && f.rms > 0.05 {
+    if f.spectral_flux > 0.01 && f.rms > rules.impact_min_rms {
         tags.push("impact_heavy".into());
     }
-    if f.centroid_hz > 1800.0 && f.zcr > 0.15 {
+    if f.centroid_hz > rules.min_centroid_hz && f.zcr > 0.15 {
         tags.push("machinery_like".into());
     }
     if f.low_band_ratio > 0.35 && f.zcr > 0.12 {
@@ -78,7 +112,8 @@ mod tests {
             low_band_ratio: 0.2,
             high_band_ratio: 0.0,
         };
-        assert!(map_tags(f).contains(&"ambience".to_string()));
+        let rules = TagRules::default();
+        assert!(map_tags(f, &rules).contains(&"ambience".to_string()));
     }
 
     #[test]
@@ -114,13 +149,60 @@ mod tests {
         writer.finalize().unwrap();
 
         // Should not panic even though segment (2s) > audio (1s)
-        add_tags(&wav_path, &mut timeline).unwrap();
+        add_tags(&wav_path, &mut timeline, None).unwrap();
         assert!(!timeline.segments[0].tags.is_empty());
 
         // Test with start > end (should be clamped and empty clip)
         timeline.segments[0].start_ms = 3000;
         timeline.segments[0].end_ms = 2000;
-        add_tags(&wav_path, &mut timeline).unwrap();
+        add_tags(&wav_path, &mut timeline, None).unwrap();
         assert!(timeline.segments[0].tags.contains(&"ambience".to_string()));
+
+        // Test that custom TagRules changes tag outcomes
+        // With default rules, rms=0.018 with low_band_ratio>0.25 and rms>0.015 matches music_bed
+        let music_f = crate::pipeline::features::FeatureSet {
+            rms: 0.018,
+            zcr: 0.1,
+            spectral_flux: 0.005,
+            spectral_flatness: 0.3,
+            spectral_entropy: 5.0,
+            centroid_hz: 500.0,
+            low_band_ratio: 0.3,
+            high_band_ratio: 0.1,
+        };
+        let default_rules = TagRules::default();
+        // Default rules: rms=0.018 > 0.012, so NOT ambience via rule; music_bed matches
+        let tags_default = map_tags(music_f, &default_rules);
+        assert!(tags_default.contains(&"music_bed".to_string()),
+            "music_bed should match with default rules");
+        assert!(!tags_default.contains(&"ambience".to_string()),
+            "ambience should not match via rule with rms=0.018");
+
+        // With raised ambience threshold, should match ambience directly
+        let high_ambience = TagRules {
+            ambience_max_rms: 0.020,
+            ..TagRules::default()
+        };
+        let tags_high = map_tags(music_f, &high_ambience);
+        assert!(tags_high.contains(&"ambience".to_string()),
+            "raised ambience_max_rms should include rms=0.018 as ambience");
+
+        // Test that tightened centroid threshold excludes machinery_like tag
+        let f_machinery = crate::pipeline::features::FeatureSet {
+            rms: 0.02,
+            zcr: 0.2,
+            spectral_flux: 0.01,
+            spectral_flatness: 0.3,
+            spectral_entropy: 5.0,
+            centroid_hz: 1900.0,
+            low_band_ratio: 0.2,
+            high_band_ratio: 0.1,
+        };
+        assert!(map_tags(f_machinery, &default_rules).contains(&"machinery_like".to_string()));
+        let tight_centroid = TagRules {
+            min_centroid_hz: 2000.0,
+            ..TagRules::default()
+        };
+        assert!(!map_tags(f_machinery, &tight_centroid).contains(&"machinery_like".to_string()));
     }
 }

--- a/tests/calibration_integration.rs
+++ b/tests/calibration_integration.rs
@@ -47,6 +47,7 @@ fn calibration_profile_changes_output() {
         name: "test".to_string(),
         energy_threshold_delta: 0.0,
         version: 1,
+        tag_thresholds: None,
     };
     std::fs::write(
         &profile,
@@ -101,11 +102,13 @@ fn positive_delta_reduces_speech_detection() {
         name: "low".to_string(),
         energy_threshold_delta: -0.005,
         version: 1,
+        tag_thresholds: None,
     };
     let high_profile = CalibrationProfile {
         name: "high".to_string(),
         energy_threshold_delta: 0.005,
         version: 1,
+        tag_thresholds: None,
     };
 
     std::fs::write(


### PR DESCRIPTION
## Summary

Implements profile-driven tag calibration, allowing genre-specific profiles to influence non-voice tag thresholds.

## Changes

**`src/learning/profiles.rs`** — Extended `CalibrationProfile` with optional `TagThresholds` containing 3 bounded per-tag threshold deltas:
- `ambience_max_rms_delta` (range: clamped to keep rms >= 0.002)
- `impact_min_rms_delta` (range: clamped to keep rms >= 0.01)
- `min_centroid_hz_delta` (range: clamped to keep centroid >= 100 Hz)

**`src/pipeline/tags.rs`** — New `TagRules` struct with 3 adjustable thresholds:
- `TagRules::default()` preserves exact current behavior
- `TagRules::from_thresholds()` creates rules from profile `TagThresholds`
- Refactored `map_tags()` to accept `&TagRules` instead of hardcoded constants
- Updated `add_tags()` to accept optional `&TagRules`

**`src/cli.rs`** — Added `--calibration-profile` argument to `Tag` command

**`src/main.rs`** — Loads profile and creates `TagRules` for the `Tag` handler

## Testing

- Existing tests pass unchanged (default rules = same behavior)
- New tests verify profile-sensitive tag outcomes:
  - Raised `ambience_max_rms` includes additional frames as ambience
  - Tightened `min_centroid_hz` excludes machinery_like tag

## Acceptance Criteria

- [x] No tag calibration data → behavior is byte-for-byte identical (default rules)
- [x] With test profile, same fixture produces different tags
- [x] Prompts change only when tags change (prompts depend on tags, unchanged)
- [x] All existing tests pass

Closes #57