### PR TITLE
Harden FFmpeg command execution

### DIFF
--- a/src/pipeline/decode.rs
+++ b/src/pipeline/decode.rs
@@ -105,12 +105,13 @@ fn decode_via_symphonia(
 
 fn decode_via_ffmpeg(path: &Path, target_sample_rate: u32) -> Result<(Vec<f32>, u32)> {
     let output = Command::new("ffmpeg")
+        .arg("-nostdin")
+        .arg("-protocol_whitelist")
+        .arg("file,pipe,fd")
+        .args(["-hide_banner", "-loglevel", "error"])
+        .arg("-i")
+        .arg(path)
         .args([
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-i",
-            &path.display().to_string(),
             "-vn",
             "-ac",
             "1",

--- a/src/verification/extractor.rs
+++ b/src/verification/extractor.rs
@@ -28,14 +28,19 @@ pub fn extract_segment_audio(
     );
 
     let output = Command::new("ffmpeg")
+        .arg("-nostdin")
+        .arg("-protocol_whitelist")
+        .arg("file,pipe,fd")
         .args([
             "-hide_banner",
             "-loglevel",
             "error",
             "-ss",
             &format!("{start_sec}"),
-            "-i",
-            &media_path.display().to_string(),
+        ])
+        .arg("-i")
+        .arg(media_path)
+        .args([
             "-t",
             &duration_str,
             "-vn",
@@ -46,8 +51,8 @@ pub fn extract_segment_audio(
             "-acodec",
             "pcm_s16le",
             "-y",
-            &output_path.display().to_string(),
         ])
+        .arg(output_path)
         .output()
         .context("failed to execute ffmpeg for segment extraction")?;
 


### PR DESCRIPTION
This PR implements security hardening for FFmpeg command execution within the audio processing pipeline. By restricting the allowed protocols to `file,pipe,fd` and disabling stdin, the application is better protected against malicious media files that might attempt to trigger network requests or other unauthorized resource access. Additionally, the change improves path handling by avoiding string conversion, which is a more robust pattern in Rust for process arguments.

---
*PR created automatically by Jules for task [5705294825822477688](https://jules.google.com/task/5705294825822477688) started by @d-oit*