### PR TITLE
Add reusable goap-agent skill for multi-step planning

### DIFF
--- a/.agents/skills/goap-agent/SKILL.md
+++ b/.agents/skills/goap-agent/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: goap-agent
+description: Multi-step GOAP planning for complex audio pipeline development. Orchestrates analysis, decomposition, strategy selection, and execution with state persistence in plans/.
+---
+
+# GOAP Agent
+
+Orchestrate complex, multi-step development tasks using Goal-Oriented Action Planning (GOAP). This skill is specifically tuned for audio processing pipelines and radio play production.
+
+## When to use
+
+- Implementing new milestones from the `ROADMAP.md`.
+- Large-scale refactors across multiple modules (e.g., `src/pipeline` to `src/goap`).
+- Tasks requiring sequential dependency management and quality gates between phases.
+- When you need to maintain state across multiple agent sessions.
+
+## Planning Workflow
+
+1.  **Analyze**: Review existing `ROADMAP.md`, `ADR-INDEX.md`, and relevant `src/` code to understand the goal.
+2.  **Decompose**: Break the goal into discrete, manageable tasks. **Requirement**: If the change introduces new architecture, an ADR must be created and approved before proceeding.
+3.  **Strategize**: Select an execution strategy (Sequential, Parallel, or Hybrid) and map dependencies.
+4.  **Coordinate**: Assign tasks to specialized agent roles (e.g., `feature-implementer`, `test-runner`).
+5.  **Execute**: Perform the work according to the strategy, updating state after each step.
+6.  **Synthesize**: Merge results, verify against the original goal, and close the plan.
+
+## Persistent State
+
+All GOAP planning state must be persisted in `plans/GOAP_STATE.md`. This allows for resumption across sessions and provides a clear audit trail.
+
+```markdown
+# GOAP State
+
+**Current Goal**: <Goal Description>
+**Status**: [Planned | In-Progress | Blocked | Complete]
+
+## Task Graph
+- [ ] Task 1 (Depends on: None)
+- [ ] Task 2 (Depends on: Task 1)
+
+## History
+- <Timestamp>: <Action Taken> -> <Result>
+```
+
+## Quality Gates
+
+Each step in the plan must pass:
+1. `cargo check` and `cargo clippy`
+2. `cargo test` for relevant modules
+3. `bash scripts/quality_gate.sh` (if applicable)
+4. Manual verification of output artifacts (e.g., JSON schema, audio headers)
+
+## Examples
+
+### Scenario A: Implementing Milestone D (Visual Gap Identification)
+
+**Goal**: Identify moments in audio that require narration.
+
+1.  **Analyze**: Read `ADR-120` and `plans/120-goap-radio-play-pipeline/ROADMAP.md`.
+2.  **Decompose**:
+    - Define `NarrationGap` struct in `src/types/`.
+    - Implement gap detection heuristics in `src/goap/gaps.rs`.
+    - Add `--analyze-only` flag to CLI.
+3.  **Strategize**: Sequential. Heuristics depend on the data structures.
+4.  **Execute**: Implement `src/types/`, then `src/goap/gaps.rs`.
+5.  **Verify**: Run `timeline radio-play --analyze-only` on `testdata/generated/alternating.wav`.
+
+### Scenario B: Adding a New TTS Provider (Milestone F)
+
+**Goal**: Add Qwen3-TTS as a German-primary synthesis provider.
+
+1.  **Analyze**: Read `ADR-121`.
+2.  **Decompose**:
+    - Implement `VoiceSynthesizer` trait for Qwen3.
+    - Add provider-specific configuration to `src/config.rs`.
+    - Create unit tests with mock API/model output.
+3.  **Strategize**: Parallel-safe (Config and Trait implementation can happen in any order).
+4.  **Execute**: Update `src/config.rs`, then implement `src/voice/qwen3.rs`.
+5.  **Synthesize**: Verify end-to-end synthesis in a test case.
+
+## Rules
+- **No Progress Without Approval**: New architecture requires an ADR in `plans/` before code changes.
+- **State First**: Update `plans/GOAP_STATE.md` before starting any new task.
+- **Atomic Commits**: Use `bash scripts/ai-commit.sh` for each completed task in the plan.

--- a/.agents/skills/goap-agent/evals/evals.json
+++ b/.agents/skills/goap-agent/evals/evals.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "milestone-d-planning",
+    "prompt": "I need to implement Milestone D from the radio-play roadmap. Create a GOAP plan to identify visual gaps in the audio.",
+    "expected_output": "The response must include a GOAP plan with state persistence in plans/GOAP_STATE.md, dependency mapping (e.g., heuristics depend on types), and specific tasks for src/goap/gaps.rs and the CLI flag."
+  },
+  {
+    "id": "new-tts-provider-planning",
+    "prompt": "Add a new TTS provider for ElevenLabs as described in ADR-121. Give me a multi-step execution strategy.",
+    "expected_output": "The response must propose a strategy (Sequential or Parallel), define tasks for trait implementation in src/voice/ and config updates in src/config.rs, and include a quality gate for verification."
+  }
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ The `VERSION` file in the root is the single source of truth. Never edit version
 - `audio-vad-cpu`: [.agents/skills/audio-vad-cpu/SKILL.md](.agents/skills/audio-vad-cpu/SKILL.md)
 - `self-learning-calibration`: [.agents/skills/self-learning-calibration/SKILL.md](.agents/skills/self-learning-calibration/SKILL.md)
 - `agent-coordination`: [.agents/skills/agent-coordination/SKILL.md](.agents/skills/agent-coordination/SKILL.md)
+- `goap-agent`: [.agents/skills/goap-agent/SKILL.md](.agents/skills/goap-agent/SKILL.md)
 - `codacy`: [.agents/skills/codacy/SKILL.md](.agents/skills/codacy/SKILL.md)
 
 ## Rules


### PR DESCRIPTION
This PR adds a new `goap-agent` skill to the repository's `.agents/skills/` directory. This skill codifies the multi-step Goal-Oriented Action Planning (GOAP) methodology already evidenced in the project's roadmaps and issue closeouts.

Key features:
- **Standardized Workflow**: Defines a clear 6-step process (Analyze, Decompose, Strategize, Coordinate, Execute, Synthesize).
- **Persistent State**: Mandates the use of `plans/GOAP_STATE.md` to maintain state across agent sessions.
- **Architecture Governance**: Requires an Approved ADR before proceeding with decomposition of new features.
- **Audio-Specific Examples**: Includes detailed planning scenarios for the radio-play pipeline (Visual Gap Identification and TTS Provider implementation).
- **Evaluation Set**: Provides realistic test cases for the skill in `evals/evals.json`.

The skill is registered in `AGENTS.md` and complies with all project standards (frontmatter, documentation links, and quality gates).

Fixes #101

---
*PR created automatically by Jules for task [5024331475960721339](https://jules.google.com/task/5024331475960721339) started by @d-oit*