### PR TITLE
Add metrics-reporter and dora-report for agent delivery measurement

### DIFF
--- a/.agents/skills/dora-report/SKILL.md
+++ b/.agents/skills/dora-report/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: dora-report
+description: Generates DORA metrics and agent delivery reports from structured events.
+---
+
+# DORA Report
+
+Aggregates events recorded by `metrics-reporter` to measure agent-assisted delivery performance.
+
+## Metrics Tracked
+
+- **Lead Time for Changes**: Time from task start to task finish.
+- **Deployment Frequency**: Number of successful 'finished' events per day/week.
+- **Change Failure Rate**: Ratio of failed 'finished' events to total 'finished' events.
+- **Mean Time to Recovery (MTTR)**: Time between a failed 'finished' event and a subsequent successful 'finished' event for the same task/scope.
+- **Human Intervention Rate**: Average number of human interventions per task.
+
+## Usage
+
+```bash
+./.agents/skills/dora-report/generate.sh
+```
+
+## Output
+
+Reports are written to `reports/dora-stats.json` and a human-readable summary to `analysis/dora-report.md`.

--- a/.agents/skills/dora-report/generate.sh
+++ b/.agents/skills/dora-report/generate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DORA Report Generator
+# Aggregates events from .agents/events/
+
+EVENTS_DIR=".agents/events"
+OUTPUT_JSON="reports/dora-stats.json"
+OUTPUT_MD="analysis/dora-report.md"
+
+mkdir -p reports analysis
+
+echo "Analyzing events in $EVENTS_DIR..."
+
+ALL_EVENTS=$(find "$EVENTS_DIR" -name "*.json" | xargs cat | jq -s '.')
+
+if [ "$ALL_EVENTS" == "[]" ]; then
+  echo "No events found."
+  exit 0
+fi
+
+# Calculate metrics using jq
+# This is a simplified calculation for the POC
+METRICS=$(echo "$ALL_EVENTS" | jq '
+  def to_epoch: . + "Z" | fromdateiso8601;
+
+  group_by(.task_id) | map({
+    task_id: .[0].task_id,
+    started: (map(select(.event_type == "started")) | sort_by(.timestamp) | .[0].timestamp),
+    finished: (map(select(.event_type == "finished")) | sort_by(.timestamp) | .[-1].timestamp),
+    success: (map(select(.event_type == "finished")) | sort_by(.timestamp) | .[-1].success),
+    interventions: (map(.human_interventions // 0) | add)
+  }) as $tasks
+  | $tasks | map(select(.started != null and .finished != null)) as $completed
+  | {
+      total_tasks: ($tasks | length),
+      completed_tasks: ($completed | length),
+      success_rate: (if ($completed | length) > 0 then ($completed | map(select(.success == true)) | length) / ($completed | length) else 0 end),
+      avg_lead_time_sec: (if ($completed | length) > 0 then ($completed | map((.finished | fromdateiso8601) - (.started | fromdateiso8601)) | add) / ($completed | length) else 0 end),
+      total_interventions: ($tasks | map(.interventions) | add),
+      avg_interventions_per_task: (if ($tasks | length) > 0 then ($tasks | map(.interventions) | add) / ($tasks | length) else 0 end)
+    }
+')
+
+echo "$METRICS" > "$OUTPUT_JSON"
+
+# Generate Markdown report
+TOTAL_TASKS=$(echo "$METRICS" | jq '.total_tasks')
+COMPLETED_TASKS=$(echo "$METRICS" | jq '.completed_tasks')
+SUCCESS_RATE=$(echo "$METRICS" | jq '.success_rate * 100')
+AVG_LEAD_TIME=$(echo "$METRICS" | jq '.avg_lead_time_sec / 60')
+AVG_INTERVENTIONS=$(echo "$METRICS" | jq '.avg_interventions_per_task')
+
+cat <<EOF > "$OUTPUT_MD"
+# DORA and Agent Delivery Report
+Generated on: $(date)
+
+## Summary Metrics
+- **Total Tasks**: $TOTAL_TASKS
+- **Completed Tasks**: $COMPLETED_TASKS
+- **Success Rate**: ${SUCCESS_RATE}%
+- **Avg. Lead Time (min)**: ${AVG_LEAD_TIME}
+- **Avg. Human Interventions**: $AVG_INTERVENTIONS
+
+## Interpretation
+- **Deployment Frequency**: Based on $COMPLETED_TASKS completions in the tracked period.
+- **Change Failure Rate**: $((100 - ${SUCCESS_RATE%.*}))% (based on success rate).
+EOF
+
+echo "Reports generated: $OUTPUT_JSON, $OUTPUT_MD"

--- a/.agents/skills/metrics-reporter/SKILL.md
+++ b/.agents/skills/metrics-reporter/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: metrics-reporter
+description: Records agent execution events for lead time, success rate, and human intervention tracking.
+---
+
+# Metrics Reporter
+
+Records structured events during agent execution to enable DORA and productivity measurement.
+
+## When to use
+
+- At the start and end of a significant task or workflow.
+- When human intervention is required.
+- When an artifact is produced.
+
+## Schema
+
+Events are stored in `.agents/events/YYYY/MM/DD/` as individual JSON files.
+Schema is defined in `schema/agent-event.schema.json`.
+
+## Usage
+
+### Recording a 'started' event
+
+```bash
+./.agents/skills/metrics-reporter/report.sh \
+  --task-id "task-123" \
+  --workflow-id "wf-456" \
+  --skill "goap-agent" \
+  --event-type "started"
+```
+
+### Recording a 'finished' event
+
+```bash
+./.agents/skills/metrics-reporter/report.sh \
+  --task-id "task-123" \
+  --workflow-id "wf-456" \
+  --skill "goap-agent" \
+  --event-type "finished" \
+  --success true \
+  --human-interventions 0 \
+  --artifacts "reports/result.html"
+```
+
+## Environment Variables
+
+- `AGENT_TASK_ID`: Optional default task ID.
+- `AGENT_WORKFLOW_ID`: Optional default workflow ID.

--- a/.agents/skills/metrics-reporter/report.sh
+++ b/.agents/skills/metrics-reporter/report.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Metrics Reporter Script
+# Usage: ./report.sh --task-id ID --workflow-id ID --skill SKILL --event-type [started|finished] [--success true/false] [--human-interventions N] [--artifacts "file1,file2"]
+
+TASK_ID=""
+WORKFLOW_ID=""
+SKILL=""
+EVENT_TYPE=""
+SUCCESS="null"
+HUMAN_INTERVENTIONS=0
+ARTIFACTS="[]"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --task-id) TASK_ID="$2"; shift 2 ;;
+    --workflow-id) WORKFLOW_ID="$2"; shift 2 ;;
+    --skill) SKILL="$2"; shift 2 ;;
+    --event-type) EVENT_TYPE="$2"; shift 2 ;;
+    --success) SUCCESS="$2"; shift 2 ;;
+    --human-interventions) HUMAN_INTERVENTIONS="$2"; shift 2 ;;
+    --artifacts)
+      IFS=',' read -r -a array <<< "$2"
+      ARTIFACTS="["
+      for i in "${!array[@]}"; do
+        ARTIFACTS+="\"${array[$i]}\""
+        if [ $i -lt $((${#array[@]} - 1)) ]; then ARTIFACTS+=","; fi
+      done
+      ARTIFACTS+="]"
+      shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [ -z "$TASK_ID" ] || [ -z "$SKILL" ] || [ -z "$EVENT_TYPE" ]; then
+  echo "Usage: $0 --task-id ID --skill SKILL --event-type [started|finished] [options]"
+  exit 1
+fi
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+GIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+DATE_PATH=$(date -u +"%Y/%m/%d")
+
+mkdir -p ".agents/events/$DATE_PATH"
+EVENT_FILE=".agents/events/$DATE_PATH/${TIMESTAMP}_${EVENT_TYPE}_${TASK_ID}.json"
+
+cat <<EOF > "$EVENT_FILE"
+{
+  "task_id": "$TASK_ID",
+  "workflow_id": "${WORKFLOW_ID:-$TASK_ID}",
+  "skill": "$SKILL",
+  "event_type": "$EVENT_TYPE",
+  "timestamp": "$TIMESTAMP",
+  "success": $SUCCESS,
+  "human_interventions": $HUMAN_INTERVENTIONS,
+  "git_sha": "$GIT_SHA",
+  "branch": "$BRANCH",
+  "artifacts": $ARTIFACTS
+}
+EOF
+
+echo "Event recorded to $EVENT_FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ The `VERSION` file in the root is the single source of truth. Never edit version
 - `codacy`: [.agents/skills/codacy/SKILL.md](.agents/skills/codacy/SKILL.md)
 - `triz-analysis`: [.agents/skills/triz-analysis/SKILL.md](.agents/skills/triz-analysis/SKILL.md)
 - `triz-solver`: [.agents/skills/triz-solver/SKILL.md](.agents/skills/triz-solver/SKILL.md)
+- `metrics-reporter`: [.agents/skills/metrics-reporter/SKILL.md](.agents/skills/metrics-reporter/SKILL.md)
+- `dora-report`: [.agents/skills/dora-report/SKILL.md](.agents/skills/dora-report/SKILL.md)
 
 ## Rules
 - **Verification**: `bash scripts/quality_gate.sh` must pass with zero warnings.

--- a/schema/agent-event.schema.json
+++ b/schema/agent-event.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://d-oit.dev/movie-radio-play/agent-event.schema.json",
+  "title": "AgentEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "task_id",
+    "workflow_id",
+    "skill",
+    "event_type",
+    "timestamp",
+    "git_sha",
+    "branch"
+  ],
+  "properties": {
+    "task_id": {
+      "type": "string",
+      "description": "Unique identifier for the task"
+    },
+    "workflow_id": {
+      "type": "string",
+      "description": "Unique identifier for the workflow session"
+    },
+    "skill": {
+      "type": "string",
+      "description": "The skill being used"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": ["started", "finished"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO8601 timestamp"
+    },
+    "success": {
+      "type": "boolean",
+      "description": "Whether the task/event was successful (only for finished)"
+    },
+    "human_interventions": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of human interventions during the task"
+    },
+    "git_sha": {
+      "type": "string"
+    },
+    "branch": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/scripts/ai-commit.sh
+++ b/scripts/ai-commit.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 bash scripts/quality_gate.sh && git add -A && git commit "$@"
+
+# Record event if metrics-reporter is available
+if [ -f ".agents/skills/metrics-reporter/report.sh" ]; then
+  # Try to use AGENT_TASK_ID, fallback to short commit SHA
+  TASK_ID="${AGENT_TASK_ID:-$(git rev-parse --short HEAD)}"
+  ./.agents/skills/metrics-reporter/report.sh \
+    --task-id "$TASK_ID" \
+    --workflow-id "${AGENT_WORKFLOW_ID:-$TASK_ID}" \
+    --skill "atomic-commit" \
+    --event-type "finished" \
+    --success true
+fi


### PR DESCRIPTION
Added a new metrics-reporting layer to the repository to track agent delivery performance. This includes a `metrics-reporter` skill for logging 'started' and 'finished' events, a `dora-report` skill for aggregating these events into DORA metrics, and integration with the existing `ai-commit.sh` script to automatically log successful completions. The event schema is documented in `schema/agent-event.schema.json`.

Fixes #104

---
*PR created automatically by Jules for task [937115513613307938](https://jules.google.com/task/937115513613307938) started by @d-oit*