### PR TITLE
Harden FFmpeg execution in radio-play handler

### DIFF
--- a/crates/movie-radio-timeline/src/handlers/radio_play.rs
+++ b/crates/movie-radio-timeline/src/handlers/radio_play.rs
@@ -235,18 +235,14 @@ fn encode_to_mp3(wav_path: &std::path::Path, mp3_path: &std::path::Path) -> Resu
     use std::process::Command;
 
     let status = Command::new("ffmpeg")
-        .args([
-            "-y",
-            "-i",
-            wav_path.to_str().unwrap_or_default(),
-            "-codec:a",
-            "libmp3lame",
-            "-b:a",
-            "192k",
-            "-q:a",
-            "2",
-            mp3_path.to_str().unwrap_or_default(),
-        ])
+        .arg("-nostdin")
+        .arg("-protocol_whitelist")
+        .arg("file,pipe,fd")
+        .args(["-hide_banner", "-loglevel", "error"])
+        .arg("-i")
+        .arg(wav_path)
+        .args(["-codec:a", "libmp3lame", "-b:a", "192k", "-q:a", "2", "-y"])
+        .arg(mp3_path)
         .status()?;
 
     if !status.success() {


### PR DESCRIPTION
Hardened FFmpeg execution in the radio-play handler to prevent SSRF, local file disclosure, and handle non-UTF-8 paths safely.

---
*PR created automatically by Jules for task [7563432595363082546](https://jules.google.com/task/7563432595363082546) started by @d-oit*