### PR TITLE
Add movie-radio-render crate for final audio mixing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,6 +2250,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "movie-radio-render"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hound",
+ "movie-radio-types",
+ "rodio",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "movie-radio-timeline"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ movie-radio-validation = { path = "crates/movie-radio-validation" }
 movie-radio-voice = { path = "crates/movie-radio-voice" }
 movie-radio-goap = { path = "crates/movie-radio-goap" }
 movie-radio-timeline = { path = "crates/movie-radio-timeline" }
+movie-radio-render = { path = "crates/movie-radio-render" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/movie-radio-render/Cargo.toml
+++ b/crates/movie-radio-render/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "movie-radio-render"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Final audio mix rendering with AGC and spatial positioning"
+
+[dependencies]
+movie-radio-types.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+hound.workspace = true
+rodio = { version = "0.22", default-features = false, features = ["wav_output", "symphonia-simd"] }
+serde.workspace = true
+tempfile = "3"
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/movie-radio-render/src/agc.rs
+++ b/crates/movie-radio-render/src/agc.rs
@@ -1,0 +1,45 @@
+use rodio::Source;
+use std::num::NonZeroU16;
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+/// Wrapper that applies rodio's AutomaticGainControl to a `Vec<f32>` sample buffer.
+/// Returns normalized f32 samples.
+pub fn apply_agc(
+    samples: Vec<f32>,
+    sample_rate: u32,
+    attack_time: f32,
+    release_time: f32,
+    absolute_max_gain: f32,
+) -> Vec<f32> {
+    let source = rodio::buffer::SamplesBuffer::new(
+        NonZeroU16::new(1).unwrap(),
+        NonZeroU32::new(sample_rate).unwrap(),
+        samples,
+    );
+    let settings = rodio::source::AutomaticGainControlSettings {
+        target_level: 1.0,
+        attack_time: Duration::from_secs_f32(attack_time),
+        release_time: Duration::from_secs_f32(release_time),
+        absolute_max_gain,
+    };
+    let agc = source.automatic_gain_control(settings);
+    agc.collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agc_silence() {
+        let samples = vec![0.0f32; 1000];
+        let normalized = apply_agc(samples, 44100, 0.1, 0.15, 10.0);
+        assert_eq!(normalized.len(), 1000);
+        for &s in &normalized {
+            assert!(!s.is_nan());
+            assert!(!s.is_infinite());
+            assert_eq!(s, 0.0);
+        }
+    }
+}

--- a/crates/movie-radio-render/src/lib.rs
+++ b/crates/movie-radio-render/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod agc;
+pub mod mixer;
+pub mod spatial;
+
+pub use mixer::{RenderConfig, RenderOutput, TrackInput, render_mix};
+pub use spatial::StereoPosition;

--- a/crates/movie-radio-render/src/lib.rs
+++ b/crates/movie-radio-render/src/lib.rs
@@ -2,5 +2,5 @@ pub mod agc;
 pub mod mixer;
 pub mod spatial;
 
-pub use mixer::{RenderConfig, RenderOutput, TrackInput, render_mix};
+pub use mixer::{render_mix, RenderConfig, RenderOutput, TrackInput};
 pub use spatial::StereoPosition;

--- a/crates/movie-radio-render/src/mixer.rs
+++ b/crates/movie-radio-render/src/mixer.rs
@@ -42,7 +42,7 @@ pub struct RenderOutput {
 ///   3. Apply constant-power stereo pan
 ///   4. Write into output stereo interleaved buffer at start_offset
 pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
-    use hound::{WavReader, WavWriter, WavSpec, SampleFormat};
+    use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
     use tracing::info;
 
     // Determine total length needed
@@ -50,7 +50,7 @@ pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
     let mut track_data: Vec<(TrackInput, Vec<f32>, u32)> = Vec::new();
 
     for track in &config.tracks {
-        let mut reader = WavReader::open(&track.wav_path)?;
+        let reader = WavReader::open(&track.wav_path)?;
         let spec = reader.spec();
         let raw: Vec<f32> = match spec.sample_format {
             hound::SampleFormat::Float => reader
@@ -80,7 +80,9 @@ pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
             track.agc_max_gain,
         );
         let end = track.start_offset_samples + normalized.len() as u64;
-        if end > total_len { total_len = end; }
+        if end > total_len {
+            total_len = end;
+        }
         track_data.push((track.clone(), normalized, sample_rate));
     }
 
@@ -91,7 +93,7 @@ pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
         let (l_gain, r_gain) = track.position.gains();
         for (i, &s) in samples.iter().enumerate() {
             let base = (track.start_offset_samples as usize + i) * 2;
-            stereo[base]     += s * l_gain;
+            stereo[base] += s * l_gain;
             stereo[base + 1] += s * r_gain;
         }
     }
@@ -99,7 +101,9 @@ pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
     // Normalise to prevent clipping
     let peak = stereo.iter().copied().map(f32::abs).fold(0.0f32, f32::max);
     if peak > 1.0 {
-        for s in &mut stereo { *s /= peak; }
+        for s in &mut stereo {
+            *s /= peak;
+        }
     }
 
     // Write output WAV
@@ -133,7 +137,7 @@ pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hound::{WavWriter, WavSpec, SampleFormat};
+    use hound::{SampleFormat, WavSpec, WavWriter};
     use tempfile::tempdir;
 
     #[test]
@@ -195,23 +199,25 @@ mod tests {
 
         // Verify output
         let reader = hound::WavReader::open(output)?;
-        let samples: Vec<f32> = reader.into_samples::<f32>().collect::<std::result::Result<_, _>>()?;
+        let samples: Vec<f32> = reader
+            .into_samples::<f32>()
+            .collect::<std::result::Result<_, _>>()?;
 
         // Track 1: L=0.5, R=0.0 (from 0 to 44100)
         // Track 2: L=0.0, R=0.5 (from 22050 to 66150)
         // Overlap (22050 to 44100): L=0.5, R=0.5.
 
         for i in 0..22050 {
-            assert!(samples[i*2] > 0.0); // L
-            assert!(samples[i*2+1].abs() < 1e-6); // R should be 0.0
+            assert!(samples[i * 2] > 0.0); // L
+            assert!(samples[i * 2 + 1].abs() < 1e-6); // R should be 0.0
         }
         for i in 22050..44100 {
-            assert!(samples[i*2] > 0.0); // L
-            assert!(samples[i*2+1] > 0.0); // R
+            assert!(samples[i * 2] > 0.0); // L
+            assert!(samples[i * 2 + 1] > 0.0); // R
         }
         for i in 44100..66150 {
-            assert!(samples[i*2].abs() < 1e-6); // L should be 0.0
-            assert!(samples[i*2+1] > 0.0); // R
+            assert!(samples[i * 2].abs() < 1e-6); // L should be 0.0
+            assert!(samples[i * 2 + 1] > 0.0); // R
         }
 
         Ok(())
@@ -237,23 +243,23 @@ mod tests {
         let config = RenderConfig {
             output_sample_rate: 44100,
             output_path: output.clone(),
-            tracks: vec![
-                TrackInput {
-                    wav_path: wav,
-                    character_id: "Loud".to_string(),
-                    position: StereoPosition::CENTRE,
-                    start_offset_samples: 0,
-                    agc_attack: 0.1,
-                    agc_release: 0.15,
-                    agc_max_gain: 1.0, // Prevent AGC from changing it too much for this test
-                },
-            ],
+            tracks: vec![TrackInput {
+                wav_path: wav,
+                character_id: "Loud".to_string(),
+                position: StereoPosition::CENTRE,
+                start_offset_samples: 0,
+                agc_attack: 0.1,
+                agc_release: 0.15,
+                agc_max_gain: 1.0, // Prevent AGC from changing it too much for this test
+            }],
         };
 
         render_mix(&config)?;
 
         let reader = hound::WavReader::open(output)?;
-        let samples: Vec<f32> = reader.into_samples::<f32>().collect::<std::result::Result<_, _>>()?;
+        let samples: Vec<f32> = reader
+            .into_samples::<f32>()
+            .collect::<std::result::Result<_, _>>()?;
         for &s in &samples {
             assert!(s.abs() <= 1.0);
         }

--- a/crates/movie-radio-render/src/mixer.rs
+++ b/crates/movie-radio-render/src/mixer.rs
@@ -1,0 +1,263 @@
+use crate::agc::apply_agc;
+use crate::spatial::StereoPosition;
+use anyhow::Result;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TrackInput {
+    /// Path to WAV file for this character segment
+    pub wav_path: PathBuf,
+    /// Character name / ID for tracing
+    pub character_id: String,
+    /// Stereo position of this character
+    pub position: StereoPosition,
+    /// Start offset in the final mix (in samples at output_sample_rate)
+    pub start_offset_samples: u64,
+    /// AGC attack time in seconds
+    pub agc_attack: f32,
+    /// AGC release time in seconds
+    pub agc_release: f32,
+    /// Max AGC gain multiplier
+    pub agc_max_gain: f32,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct RenderConfig {
+    pub output_sample_rate: u32,
+    pub output_path: PathBuf,
+    pub tracks: Vec<TrackInput>,
+}
+
+#[derive(Debug)]
+pub struct RenderOutput {
+    pub output_path: PathBuf,
+    pub total_samples: u64,
+    pub duration_secs: f64,
+}
+
+/// Render all tracks into a stereo WAV output.
+/// Steps per track:
+///   1. Load WAV via hound
+///   2. Apply AGC via rodio
+///   3. Apply constant-power stereo pan
+///   4. Write into output stereo interleaved buffer at start_offset
+pub fn render_mix(config: &RenderConfig) -> Result<RenderOutput> {
+    use hound::{WavReader, WavWriter, WavSpec, SampleFormat};
+    use tracing::info;
+
+    // Determine total length needed
+    let mut total_len: u64 = 0;
+    let mut track_data: Vec<(TrackInput, Vec<f32>, u32)> = Vec::new();
+
+    for track in &config.tracks {
+        let mut reader = WavReader::open(&track.wav_path)?;
+        let spec = reader.spec();
+        let raw: Vec<f32> = match spec.sample_format {
+            hound::SampleFormat::Float => reader
+                .into_samples::<f32>()
+                .collect::<std::result::Result<_, _>>()?,
+            hound::SampleFormat::Int => {
+                let bits = spec.bits_per_sample;
+                let max_val = (1i64 << (bits - 1)) as f32;
+                reader
+                    .into_samples::<i32>()
+                    .map(|s| s.map(|v| v as f32 / max_val))
+                    .collect::<std::result::Result<_, _>>()?
+            }
+        };
+        let sample_rate = spec.sample_rate;
+        let mono: Vec<f32> = if spec.channels == 2 {
+            raw.chunks(2).map(|c| (c[0] + c[1]) * 0.5).collect()
+        } else {
+            raw
+        };
+        // AGC
+        let normalized = apply_agc(
+            mono,
+            sample_rate,
+            track.agc_attack,
+            track.agc_release,
+            track.agc_max_gain,
+        );
+        let end = track.start_offset_samples + normalized.len() as u64;
+        if end > total_len { total_len = end; }
+        track_data.push((track.clone(), normalized, sample_rate));
+    }
+
+    // Allocate stereo output buffer (interleaved L/R)
+    let mut stereo = vec![0.0f32; (total_len * 2) as usize];
+
+    for (track, samples, _sr) in &track_data {
+        let (l_gain, r_gain) = track.position.gains();
+        for (i, &s) in samples.iter().enumerate() {
+            let base = (track.start_offset_samples as usize + i) * 2;
+            stereo[base]     += s * l_gain;
+            stereo[base + 1] += s * r_gain;
+        }
+    }
+
+    // Normalise to prevent clipping
+    let peak = stereo.iter().copied().map(f32::abs).fold(0.0f32, f32::max);
+    if peak > 1.0 {
+        for s in &mut stereo { *s /= peak; }
+    }
+
+    // Write output WAV
+    let spec = WavSpec {
+        channels: 2,
+        sample_rate: config.output_sample_rate,
+        bits_per_sample: 32,
+        sample_format: SampleFormat::Float,
+    };
+    let mut writer = WavWriter::create(&config.output_path, spec)?;
+    for s in &stereo {
+        writer.write_sample(*s)?;
+    }
+    writer.finalize()?;
+
+    let duration_secs = total_len as f64 / config.output_sample_rate as f64;
+    info!(
+        output = %config.output_path.display(),
+        duration_secs,
+        tracks = config.tracks.len(),
+        "render_mix complete"
+    );
+
+    Ok(RenderOutput {
+        output_path: config.output_path.clone(),
+        total_samples: total_len,
+        duration_secs,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hound::{WavWriter, WavSpec, SampleFormat};
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_render_mix_basic() -> Result<()> {
+        let dir = tempdir()?;
+        let wav1 = dir.path().join("track1.wav");
+        let wav2 = dir.path().join("track2.wav");
+        let output = dir.path().join("output.wav");
+
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 44100,
+            bits_per_sample: 32,
+            sample_format: SampleFormat::Float,
+        };
+
+        // Track 1: 1.0 second of 0.5 amplitude
+        let mut writer1 = WavWriter::create(&wav1, spec)?;
+        for _ in 0..44100 {
+            writer1.write_sample(0.5f32)?;
+        }
+        writer1.finalize()?;
+
+        // Track 2: 1.0 second of 0.5 amplitude
+        let mut writer2 = WavWriter::create(&wav2, spec)?;
+        for _ in 0..44100 {
+            writer2.write_sample(0.5f32)?;
+        }
+        writer2.finalize()?;
+
+        let config = RenderConfig {
+            output_sample_rate: 44100,
+            output_path: output.clone(),
+            tracks: vec![
+                TrackInput {
+                    wav_path: wav1,
+                    character_id: "A".to_string(),
+                    position: StereoPosition::HARD_LEFT,
+                    start_offset_samples: 0,
+                    agc_attack: 0.1,
+                    agc_release: 0.15,
+                    agc_max_gain: 1.0,
+                },
+                TrackInput {
+                    wav_path: wav2,
+                    character_id: "B".to_string(),
+                    position: StereoPosition::HARD_RIGHT,
+                    start_offset_samples: 22050, // 0.5s offset
+                    agc_attack: 0.1,
+                    agc_release: 0.15,
+                    agc_max_gain: 1.0,
+                },
+            ],
+        };
+
+        let result = render_mix(&config)?;
+        assert!(result.output_path.exists());
+        assert_eq!(result.total_samples, 44100 + 22050);
+
+        // Verify output
+        let reader = hound::WavReader::open(output)?;
+        let samples: Vec<f32> = reader.into_samples::<f32>().collect::<std::result::Result<_, _>>()?;
+
+        // Track 1: L=0.5, R=0.0 (from 0 to 44100)
+        // Track 2: L=0.0, R=0.5 (from 22050 to 66150)
+        // Overlap (22050 to 44100): L=0.5, R=0.5.
+
+        for i in 0..22050 {
+            assert!(samples[i*2] > 0.0); // L
+            assert!(samples[i*2+1].abs() < 1e-6); // R should be 0.0
+        }
+        for i in 22050..44100 {
+            assert!(samples[i*2] > 0.0); // L
+            assert!(samples[i*2+1] > 0.0); // R
+        }
+        for i in 44100..66150 {
+            assert!(samples[i*2].abs() < 1e-6); // L should be 0.0
+            assert!(samples[i*2+1] > 0.0); // R
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_peak_normalization() -> Result<()> {
+        let dir = tempdir()?;
+        let wav = dir.path().join("loud.wav");
+        let output = dir.path().join("normalized.wav");
+
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: 44100,
+            bits_per_sample: 32,
+            sample_format: SampleFormat::Float,
+        };
+
+        let mut writer = WavWriter::create(&wav, spec)?;
+        writer.write_sample(2.0f32)?;
+        writer.finalize()?;
+
+        let config = RenderConfig {
+            output_sample_rate: 44100,
+            output_path: output.clone(),
+            tracks: vec![
+                TrackInput {
+                    wav_path: wav,
+                    character_id: "Loud".to_string(),
+                    position: StereoPosition::CENTRE,
+                    start_offset_samples: 0,
+                    agc_attack: 0.1,
+                    agc_release: 0.15,
+                    agc_max_gain: 1.0, // Prevent AGC from changing it too much for this test
+                },
+            ],
+        };
+
+        render_mix(&config)?;
+
+        let reader = hound::WavReader::open(output)?;
+        let samples: Vec<f32> = reader.into_samples::<f32>().collect::<std::result::Result<_, _>>()?;
+        for &s in &samples {
+            assert!(s.abs() <= 1.0);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/movie-radio-render/src/spatial.rs
+++ b/crates/movie-radio-render/src/spatial.rs
@@ -1,0 +1,24 @@
+/// Stereo pan position for a character voice track.
+/// -1.0 = full left, 0.0 = centre, 1.0 = full right
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct StereoPosition(pub f32);
+
+impl StereoPosition {
+    pub const CENTRE: Self = Self(0.0);
+    pub const LEFT: Self = Self(-0.7);
+    pub const RIGHT: Self = Self(0.7);
+    pub const HARD_LEFT: Self = Self(-1.0);
+    pub const HARD_RIGHT: Self = Self(1.0);
+
+    /// Validate position is in [-1.0, 1.0]
+    pub fn new(pos: f32) -> anyhow::Result<Self> {
+        anyhow::ensure!((-1.0..=1.0).contains(&pos), "position must be in [-1.0, 1.0]");
+        Ok(Self(pos))
+    }
+
+    /// Constant-power pan: returns (left_gain, right_gain)
+    pub fn gains(self) -> (f32, f32) {
+        let angle = (self.0 + 1.0) * std::f32::consts::FRAC_PI_4; // 0..pi/2
+        (angle.cos(), angle.sin())
+    }
+}

--- a/crates/movie-radio-render/src/spatial.rs
+++ b/crates/movie-radio-render/src/spatial.rs
@@ -12,7 +12,10 @@ impl StereoPosition {
 
     /// Validate position is in [-1.0, 1.0]
     pub fn new(pos: f32) -> anyhow::Result<Self> {
-        anyhow::ensure!((-1.0..=1.0).contains(&pos), "position must be in [-1.0, 1.0]");
+        anyhow::ensure!(
+            (-1.0..=1.0).contains(&pos),
+            "position must be in [-1.0, 1.0]"
+        );
         Ok(Self(pos))
     }
 


### PR DESCRIPTION
This PR introduces the `movie-radio-render` crate, which is responsible for the final audio mix stage. It takes rendered TTS WAV segments, applies Automatic Gain Control (AGC) per track using `rodio`, positions each character spatially in stereo, and writes the final mixed WAV via `hound`.

Key features:
- **AGC**: Uses `rodio`'s `AutomaticGainControl` for loudness normalization.
- **Spatial Positioning**: Implements constant-power panning for character tracks.
- **Mixing**: Composites multiple tracks with start offsets and peak normalization to prevent clipping.
- **WAV Support**: Handles both Int and Float PCM formats.

The implementation is verified with unit tests and is compatible with `rodio` 0.22. It also includes build fixes to support sandboxed environments by disabling the ALSA-dependent `playback` feature of `rodio`.

Fixes #120

---
*PR created automatically by Jules for task [7501150149854705325](https://jules.google.com/task/7501150149854705325) started by @d-oit*