### PR TITLE
Prevent DoS by removing panics in audio rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ dependencies = [
 name = "movie-radio-render"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "movie-radio-types",
  "rodio",
  "serde",

--- a/crates/movie-radio-render/Cargo.toml
+++ b/crates/movie-radio-render/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Audio rendering and mixing for radio plays"
 
 [dependencies]
+anyhow.workspace = true
 movie-radio-types.workspace = true
 rodio = { version = "0.22", default-features = false, features = ["wav_output", "noise"] }
 serde.workspace = true

--- a/crates/movie-radio-render/src/agc.rs
+++ b/crates/movie-radio-render/src/agc.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use rodio::Source;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::time::Duration;
@@ -9,21 +10,22 @@ pub fn apply_reverb(
     sample_rate: u32,
     delay_ms: u64,
     amplitude: f32,
-) -> Vec<f32> {
+) -> Result<Vec<f32>> {
     if delay_ms == 0 || amplitude == 0.0 {
-        return samples; // skip processing for dry signal
+        return Ok(samples); // skip processing for dry signal
     }
 
-    let channels = NonZeroU16::new(1).expect("1 is non-zero");
-    let sample_rate_nz = NonZeroU32::new(sample_rate).expect("sample rate is non-zero");
+    let channels = NonZeroU16::new(1).context("1 is non-zero")?;
+    let sample_rate_nz =
+        NonZeroU32::new(sample_rate).context("sample rate must be greater than zero")?;
 
     let source = rodio::buffer::SamplesBuffer::new(channels, sample_rate_nz, samples);
     let with_reverb = source.reverb(Duration::from_millis(delay_ms), amplitude);
-    with_reverb.collect()
+    Ok(with_reverb.collect())
 }
 
 /// Placeholder for Automatic Gain Control.
-pub fn apply_agc(samples: Vec<f32>, _sample_rate: u32) -> Vec<f32> {
+pub fn apply_agc(samples: Vec<f32>, _sample_rate: u32) -> Result<Vec<f32>> {
     // Current placeholder logic: pass-through
-    samples
+    Ok(samples)
 }

--- a/crates/movie-radio-render/src/mixer.rs
+++ b/crates/movie-radio-render/src/mixer.rs
@@ -1,5 +1,6 @@
 use crate::agc::{apply_agc, apply_reverb};
 use crate::spatial::{ReverbConfig, StereoPosition};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 /// Input track for the mixer
@@ -18,18 +19,18 @@ pub struct TrackInput {
 }
 
 /// Renders a mix of tracks into a stereo output.
-pub fn render_mix(tracks: Vec<TrackInput>) -> Vec<f32> {
+pub fn render_mix(tracks: Vec<TrackInput>) -> Result<Vec<f32>> {
     let mut _mixed = Vec::new();
 
     for track in tracks {
         let sample_rate = track.sample_rate;
 
         // 1. Apply AGC
-        let normalized = apply_agc(track.samples, sample_rate);
+        let normalized = apply_agc(track.samples, sample_rate)?;
 
         // 2. Apply Reverb
         let with_reverb = if let Some(ref rev) = track.reverb {
-            apply_reverb(normalized, sample_rate, rev.delay_ms, rev.amplitude)
+            apply_reverb(normalized, sample_rate, rev.delay_ms, rev.amplitude)?
         } else {
             normalized
         };
@@ -40,7 +41,7 @@ pub fn render_mix(tracks: Vec<TrackInput>) -> Vec<f32> {
         // Mixing logic would go here
     }
 
-    _mixed
+    Ok(_mixed)
 }
 
 /// Placeholder for spatial panning
@@ -51,31 +52,34 @@ fn apply_spatial(samples: Vec<f32>, _position: StereoPosition) -> Vec<f32> {
 #[cfg(test)]
 mod tests {
     use crate::spatial::ReverbConfig;
+    use anyhow::Result;
 
     #[test]
-    fn reverb_does_not_produce_nan() {
+    fn reverb_does_not_produce_nan() -> Result<()> {
         let samples: Vec<f32> = (0..4800).map(|i| (i as f32 * 0.001).sin() * 0.5).collect();
         let result = crate::agc::apply_reverb(
             samples,
             48000,
             ReverbConfig::MEDIUM_ROOM.delay_ms,
             ReverbConfig::MEDIUM_ROOM.amplitude,
-        );
+        )?;
         assert!(
             result.iter().all(|s| s.is_finite()),
             "reverb produced NaN/Inf"
         );
+        Ok(())
     }
 
     #[test]
-    fn dry_reverb_is_passthrough() {
+    fn dry_reverb_is_passthrough() -> Result<()> {
         let samples: Vec<f32> = vec![0.1, 0.2, 0.3, -0.1, -0.2];
         let result = crate::agc::apply_reverb(
             samples.clone(),
             44100,
             ReverbConfig::DRY.delay_ms,
             ReverbConfig::DRY.amplitude,
-        );
+        )?;
         assert_eq!(result, samples);
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR refactors the audio rendering functions in the movie-radio-render crate to return Result instead of panicking on invalid inputs (like a zero sample rate). This improves the application's availability and follows the project's strict policy against unwrap() and expect() in crates.

---
*PR created automatically by Jules for task [348615504543299589](https://jules.google.com/task/348615504543299589) started by @d-oit*