### PR TITLE
chore: changelog entries and gap-helper unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+- perf(verification): pre-allocated magnitude buffers and branchless spectral summation, ~7.5% faster spectral feature extraction (#193).
+- refactor(pipeline): extracted `run_pipeline` processing stages into focused helpers with a shared `timed_stage!` macro (#189).
+- refactor(goap): split `identify_gaps` signal analysis into dedicated helper methods (#188).
+- build(deps): bumped `clap` to 4.6.6 (#192).
+
 ## 0.1.0
 - Initial production-oriented CLI with `extract`/`tag`/`prompt`/`calibrate`/`bench`.
 - Added spectral VAD path and profile-driven threshold controls.

--- a/crates/movie-radio-goap/src/gaps.rs
+++ b/crates/movie-radio-goap/src/gaps.rs
@@ -255,4 +255,153 @@ mod tests {
         // 0.4 (duration) + 0.2 (ambience) + 0.2 (surrounding speech) = 0.8
         assert!(output.gaps[0].confidence >= 0.79);
     }
+
+    fn segment(start_ms: u64, end_ms: u64, kind: SegmentKind, tags: &[&str]) -> Segment {
+        Segment {
+            start_ms,
+            end_ms,
+            kind,
+            confidence: 1.0,
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            prompt: None,
+        }
+    }
+
+    #[test]
+    fn test_analyze_duration_signal() {
+        let id = GapIdentifier::default();
+        let mut c = 0.0;
+        let mut r = Vec::new();
+
+        // Below 1s: no contribution.
+        id.analyze_duration(800, &mut c, &mut r);
+        assert_eq!(c, 0.0);
+        assert!(r.is_empty());
+
+        // 1s..=3s: small boost only.
+        id.analyze_duration(2500, &mut c, &mut r);
+        assert!((c - 0.1).abs() < 1e-6);
+        assert!(r.is_empty());
+
+        // > min_silence_duration_ms: strong boost plus reason.
+        id.analyze_duration(4000, &mut c, &mut r);
+        assert!((c - 0.5).abs() < 1e-6);
+        assert_eq!(r, vec!["Duration (4000ms) > 3s".to_string()]);
+    }
+
+    #[test]
+    fn test_analyze_tag_context() {
+        let id = GapIdentifier::default();
+        let mut c = 0.0;
+        let mut r = Vec::new();
+
+        // Ambience only counts when the segment is longer than 2s.
+        id.analyze_tag_context(&["ambience".to_string()], 1500, &mut c, &mut r);
+        assert_eq!(c, 0.0);
+        id.analyze_tag_context(&["ambience".to_string()], 3000, &mut c, &mut r);
+        assert!((c - 0.2).abs() < 1e-6);
+        assert_eq!(r, vec!["Extended ambience".to_string()]);
+
+        // impact_heavy / machinery_like always boost.
+        id.analyze_tag_context(&["impact_heavy".to_string()], 1000, &mut c, &mut r);
+        assert!((c - 0.5).abs() < 1e-6);
+        assert_eq!(r[1], "Ambiguous SFX needing description".to_string());
+
+        // music_bed only counts when longer than 5s.
+        id.analyze_tag_context(&["music_bed".to_string()], 4000, &mut c, &mut r);
+        assert!((c - 0.5).abs() < 1e-6);
+        id.analyze_tag_context(&["music_bed".to_string()], 6000, &mut c, &mut r);
+        assert!((c - 0.6).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_analyze_dialogue_proximity() {
+        let id = GapIdentifier::default();
+        let segments = vec![
+            segment(0, 1000, SegmentKind::Speech, &[]),
+            segment(1000, 2000, SegmentKind::NonVoice, &[]),
+            segment(2000, 3000, SegmentKind::Speech, &[]),
+        ];
+
+        // Between two speech blocks.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_dialogue_proximity(1, &segments, &mut c, &mut r);
+        assert!((c - 0.2).abs() < 1e-6);
+        assert_eq!(r, vec!["Gap between dialogue blocks".to_string()]);
+
+        // Speech only on one side: no boost.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_dialogue_proximity(1, &segments[..2], &mut c, &mut r);
+        assert_eq!(c, 0.0);
+
+        // First segment has no predecessor: no boost.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_dialogue_proximity(0, &segments, &mut c, &mut r);
+        assert_eq!(c, 0.0);
+    }
+
+    #[test]
+    fn test_analyze_audio_environment_change() {
+        let id = GapIdentifier::default();
+        let segments = vec![
+            segment(0, 1000, SegmentKind::Speech, &["indoor"]),
+            segment(1000, 2000, SegmentKind::NonVoice, &[]),
+            segment(2000, 3000, SegmentKind::Speech, &["outdoor"]),
+        ];
+
+        // Disjoint, non-empty tag sets: scene change detected.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_audio_environment_change(1, &segments, &mut c, &mut r);
+        assert!((c - 0.3).abs() < 1e-6);
+        assert_eq!(r, vec!["Audio environment change detected".to_string()]);
+
+        // Overlapping tag sets: no scene change.
+        let overlapping = vec![
+            segment(0, 1000, SegmentKind::Speech, &["indoor"]),
+            segment(1000, 2000, SegmentKind::NonVoice, &[]),
+            segment(2000, 3000, SegmentKind::Speech, &["indoor", "outdoor"]),
+        ];
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_audio_environment_change(1, &overlapping, &mut c, &mut r);
+        assert_eq!(c, 0.0);
+
+        // Boundary index: no scene change.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_audio_environment_change(0, &segments, &mut c, &mut r);
+        assert_eq!(c, 0.0);
+    }
+
+    #[test]
+    fn test_analyze_subtitle_gap() {
+        let id = GapIdentifier::default();
+        let subs = vec![
+            segment(0, 1000, SegmentKind::Speech, &[]),
+            segment(2000, 3000, SegmentKind::Speech, &[]),
+        ];
+
+        // Segment fully inside the subtitle gap: confirmed.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_subtitle_gap(1200, 1800, &Some(subs.clone()), &mut c, &mut r);
+        assert!((c - 0.2).abs() < 1e-6);
+        assert_eq!(r, vec!["Confirmed by subtitle gap".to_string()]);
+
+        // Segment overlapping a subtitle: not confirmed.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_subtitle_gap(900, 1500, &Some(subs.clone()), &mut c, &mut r);
+        assert_eq!(c, 0.0);
+
+        // No subtitles available: no contribution.
+        let mut c = 0.0;
+        let mut r = Vec::new();
+        id.analyze_subtitle_gap(1200, 1800, &None, &mut c, &mut r);
+        assert_eq!(c, 0.0);
+    }
 }


### PR DESCRIPTION
Follow-up polish after the merged PR batch:

- **CHANGELOG**: document the merged perf/refactor/deps changes (#192, #193, #189, #188) under an `Unreleased` section.
- **gaps.rs**: unit tests for all five `identify_gaps` signal helpers (duration, tag context, dialogue proximity, audio environment change, subtitle gap).
- **Labels**: created the missing `dependencies`, `rust` and `ci` labels so dependabot stops warning about unknown labels (no file change needed for dependabot.yml).