### PR TITLE
docs: add triage policy to CONTRIBUTING.md and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-change.yml
+++ b/.github/ISSUE_TEMPLATE/agent-change.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for proposing a change to the agent or harness workflow! Please detail the skill or config adjustments below.
+        Thanks for proposing a change to the agent or harness workflow! Please detail the skill or config adjustments below. Open issues and PRs are triaged weekly — see CONTRIBUTING.md.
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/coding-change.yml
+++ b/.github/ISSUE_TEMPLATE/coding-change.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for proposing a coding change! Please fill out the details below to help us and our agents implement and verify it consistently.
+        Thanks for proposing a coding change! Fill out the details below so we and our agents can implement and verify it consistently. Open issues and PRs are triaged weekly (see CONTRIBUTING.md).
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/perf-change.yml
+++ b/.github/ISSUE_TEMPLATE/perf-change.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for proposing a performance change! Please specify the metrics, targets, and benchmark plan.
+        Thanks for proposing a performance change! Please specify the metrics, targets, and benchmark plan. Open issues and PRs are triaged weekly — see CONTRIBUTING.md.
   - type: textarea
     id: description
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thanks for contributing to Movie Radio Play! Development is shared between
+humans and automated agents; both follow the same rules (see `AGENTS.md` for
+the canonical workflow and quality requirements).
+
+## Workflow
+
+1. Open an issue using the GitHub issue templates (`Coding Change`,
+   `Performance Change`, or `Agent/Harness Change`).
+2. Implement the change in minimal, atomic commits and run
+   `bash scripts/quality_gate.sh` before pushing.
+3. Open a pull request — every CI check (Quality Gate, CodeQL, Codacy,
+   DeepSource, Repowise) must pass before it can merge.
+
+## Issue & PR Triage Policy
+
+The repository aims to keep **zero open issues and PRs**. To stay on top of
+the queue:
+
+- A weekly reminder workflow (`.github/workflows/triage-reminder.yml`) runs
+  every **Monday 09:00 UTC** (also triggerable manually).
+- It flags any open issue or PR with no activity in the last **7 days** by
+  opening or updating a `triage`-labeled reminder issue.
+- Triaging an item means: close no-impact issues with a brief rationale,
+  address review comments, and merge PRs in dependency order — or explicitly
+  defer them with a comment.
+
+## Merge Rules
+
+- `main` is protected: all required status checks must pass, and branches
+  must be up to date before merging.
+- Merges are squash merges; merged branches are deleted automatically.
+- Force pushes and deletions on `main` are disabled.


### PR DESCRIPTION
## Summary
Followups from the triage closeout:

1. **CONTRIBUTING.md** (new) — documents the workflow, the weekly triage policy (Mondays 09:00 UTC, 7-day stale threshold, zero-open-queue goal), and the merge rules on protected `main`.
2. **Issue templates** — all three templates now point to the triage policy in their intro.

Note: `main` is now branch-protected (8 required checks: CI Success, CodeQL ×4, Codacy, DeepSource, Repowise; strict; no force pushes). This PR is the first to validate the protection end-to-end.