### PR TITLE
chore: gate dependabot auto-merge to patch/minor, record followups

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,8 +13,21 @@ jobs:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch/minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
+      - name: Skip major and other updates
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-minor'
+        run: echo "Skipping auto-merge for update-type '${{ steps.metadata.outputs.update-type }}' (manual review required)"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        # Pinned to the commit SHA of the v2 tag for immutability (Codacy rule).
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for patch/minor updates

--- a/plans/120-issue-pr-triage-2026-08-18.md
+++ b/plans/120-issue-pr-triage-2026-08-18.md
@@ -55,7 +55,7 @@ recovered.
 ## Followups (completed same day)
 
 | PR | Change |
-|----|--------|
+| --- | ------ |
 | 199 | Weekly triage reminder workflow, AGENTS.md Recent-Merges/Triage sections, closeout report |
 | 200 | CONTRIBUTING.md triage policy + issue-template pointers; enabled branch protection |
 | — | Dependabot auto-merge hardened to skip `semver-major` bumps |

--- a/plans/120-issue-pr-triage-2026-08-18.md
+++ b/plans/120-issue-pr-triage-2026-08-18.md
@@ -49,13 +49,37 @@ recovered.
 - GitHub incidents break CodeQL *and* DeepSource webhook delivery simultaneously;
   status contexts for DeepSource are `commit statuses`, not check-runs.
 - DeepSource skips identical-tree commits — re-triggering requires a real diff.
-- No branch protection exists on `main`; CodeQL is not a required check, but was
-  still pushed to green for hygiene.
+- Branch protection did not exist at triage time; it was added in the followups
+  below (see "Followups").
+
+## Followups (completed same day)
+
+| PR | Change |
+|----|--------|
+| 199 | Weekly triage reminder workflow, AGENTS.md Recent-Merges/Triage sections, closeout report |
+| 200 | CONTRIBUTING.md triage policy + issue-template pointers; enabled branch protection |
+| — | Dependabot auto-merge hardened to skip `semver-major` bumps |
+
+### Branch protection (live)
+
+- Required checks: `CI Success`, CodeQL ×4, `Codacy Static Code Analysis`,
+  `DeepSource: Analysis`, `Repowise / code health` (8 contexts).
+- `strict` (branches up to date), `enforce_admins`, no force pushes, no deletions,
+  conversation resolution required, delete-branch-on-merge.
+- No PR-approval requirement (keeps the dependabot auto-merge flow working).
+- Verified with a deliberately broken PR (#201): `mergeable_state: blocked` and the
+  merge API returned 405 ("Required status check \"CI Success\" is failing").
+
+### Weekly triage reminder
+
+- `.github/workflows/triage-reminder.yml` runs Mondays 09:00 UTC (manual trigger
+  supported). Flags open items with no activity in 7+ days into a `triage`-labeled
+  issue; does nothing when the queue is clean (verified end-to-end).
 
 ## Final State
 
-- `main` (41023d7): Quality Gate ✅, CodeQL ✅, Codacy 0 issues, DeepSource clean,
-  fmt clean, 44+17 local tests green.
+- `main` (cf488b6): Quality Gate ✅, CodeQL ✅, Codacy 0 issues, DeepSource clean,
+  fmt clean; branch protection active and verified.
 - Zero open PRs, zero open issues.
-- Followup: weekly triage reminder workflow (`.github/workflows/triage-reminder.yml`)
-  added to keep the queue at zero.
+- Weekly triage reminder + CONTRIBUTING.md policy keep the queue at zero going
+  forward.


### PR DESCRIPTION
## Summary
1. **Dependabot auto-merge hardening** — `.github/workflows/dependabot-automerge.yml` now uses `dependabot/fetch-metadata` to auto-merge only `semver-patch` and `semver-minor` updates. `semver-major` bumps (e.g. rubato 4→5) are left for manual review instead of auto-merging silently.
2. **Closeout report** — `plans/120-issue-pr-triage-2026-08-18.md` now records the followups: branch protection (8 required checks, verified blocked via PR #201), weekly triage reminder, and this dependabot hardening.

## Verification
- `yamllint` on the workflow: clean
- `scripts/validate-workflows.sh`: passes
- The existing `enable-automerge` job is unchanged for patch/minor PRs; major bumps now log a skip message.