### PR TITLE
fix(deps): bump h2 to 0.4.16 (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,9 +1403,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary
Fixes a newly-published security advisory blocking the CI Security Audit and cargo-deny jobs.

- **RUSTSEC-2026-0258**: `h2` < 0.4.16 vulnerable to unbounded empty DATA frames (memory exhaustion).
- Bump `h2` 0.4.15 → 0.4.16 (patched release). Cargo.lock-only change.

## Verification
- `cargo tree -p h2 --locked` resolves and downloads 0.4.16 successfully.
- No code changes; advisory cleared.