### PR TITLE
feat(voice): configurable OpenAI-compatible TTS endpoint (German sidecar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- feat(voice): configurable OpenAI-compatible TTS endpoint — `base_url` + optional auth enables local German sidecars (audio.cpp/PocketTTS) with OpenAI as default (#212).
+- fix(voice): validate `SynthesisRequest` parameters (sample-rate bounds, finite speed, text cap) before TTS dispatch; typed validation errors (#209).
 - perf(verification): pre-allocated magnitude buffers and branchless spectral summation, ~7.5% faster spectral feature extraction (#193).
 - refactor(pipeline): extracted `run_pipeline` processing stages into focused helpers with a shared `timed_stage!` macro (#189).
 - refactor(goap): split `identify_gaps` signal analysis into dedicated helper methods (#188).

--- a/crates/movie-radio-timeline/src/handlers/radio_play.rs
+++ b/crates/movie-radio-timeline/src/handlers/radio_play.rs
@@ -138,12 +138,7 @@ fn run_full_pipeline(
                 endpoint_url_env: "MODAL_TTS_ENDPOINT".to_string(),
                 max_monthly_cost: 25.0,
             }),
-            openai: std::env::var("OPENAI_API_KEY").ok().map(|_| OpenAiConfig {
-                api_key_env: "OPENAI_API_KEY".to_string(),
-                model: "tts-1-hd".to_string(),
-                voice: "onyx".to_string(),
-                response_format: "mp3".to_string(),
-            }),
+            openai: openai_config_from_env(),
         },
     };
 
@@ -249,4 +244,36 @@ fn encode_to_mp3(wav_path: &std::path::Path, mp3_path: &std::path::Path) -> Resu
         bail!("ffmpeg MP3 encoding failed");
     }
     Ok(())
+}
+
+/// Builds the OpenAI-compatible TTS config from the environment.
+///
+/// Default remains the public OpenAI API when `OPENAI_API_KEY` is set.
+/// Alternatively, `OPENAI_TTS_BASE_URL` selects an OpenAI-compatible local
+/// server (e.g. an audio.cpp sidecar) without authentication, defaulting to
+/// the German PocketTTS recipe (voice `alba`, WAV output).
+fn openai_config_from_env() -> Option<OpenAiConfig> {
+    if std::env::var("OPENAI_API_KEY").is_ok() {
+        return Some(OpenAiConfig {
+            api_key_env: Some("OPENAI_API_KEY".to_string()),
+            base_url: movie_radio_voice::config::default_openai_base_url(),
+            model: "tts-1-hd".to_string(),
+            voice: "onyx".to_string(),
+            response_format: "mp3".to_string(),
+        });
+    }
+
+    std::env::var("OPENAI_TTS_BASE_URL").ok().map(|base_url| {
+        info!(
+            base_url = %base_url,
+            "Using OpenAI-compatible TTS sidecar (German PocketTTS defaults)"
+        );
+        OpenAiConfig {
+            api_key_env: None,
+            base_url,
+            model: "pocket-tts".to_string(),
+            voice: "alba".to_string(),
+            response_format: "wav".to_string(),
+        }
+    })
 }

--- a/crates/movie-radio-voice/src/config.rs
+++ b/crates/movie-radio-voice/src/config.rs
@@ -66,8 +66,20 @@ pub struct ElevenLabsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenAiConfig {
-    pub api_key_env: String,
+    /// Environment variable holding the bearer token. `None` disables the
+    /// Authorization header entirely — for OpenAI-compatible local servers
+    /// such as an audio.cpp sidecar.
+    #[serde(default)]
+    pub api_key_env: Option<String>,
+    /// API root. Defaults to the public OpenAI API; point it at a local
+    /// OpenAI-compatible TTS server (e.g. audio.cpp) to switch engines.
+    #[serde(default = "default_openai_base_url")]
+    pub base_url: String,
     pub model: String,
     pub voice: String,
     pub response_format: String,
+}
+
+pub fn default_openai_base_url() -> String {
+    "https://api.openai.com/v1".to_string()
 }

--- a/crates/movie-radio-voice/src/voice/openai.rs
+++ b/crates/movie-radio-voice/src/voice/openai.rs
@@ -18,34 +18,49 @@ impl OpenAiTtsProvider {
             client: Client::new(),
         }
     }
+
+    /// Full TTS endpoint derived from the configured API root.
+    fn endpoint(&self) -> String {
+        let base = self.config.base_url.trim_end_matches('/');
+        format!("{}/audio/speech", base)
+    }
+
+    /// Resolves the bearer token from `api_key_env`, if one is configured.
+    /// `Ok(None)` means "send no Authorization header" (local sidecars).
+    fn auth_header(&self) -> Result<Option<String>> {
+        match &self.config.api_key_env {
+            Some(env_name) => env::var(env_name)
+                .map(|token| Some(format!("Bearer {}", token)))
+                .with_context(|| format!("Environment variable {} not set", env_name)),
+            None => Ok(None),
+        }
+    }
 }
 
 #[async_trait]
 impl VoiceSynthesizer for OpenAiTtsProvider {
     async fn synthesize(&self, request: &SynthesisRequest) -> Result<AudioOutput> {
-        let api_key = env::var(&self.config.api_key_env)
-            .with_context(|| format!("Environment variable {} not set", self.config.api_key_env))?;
-
         let voice = if let Some(ref voice_id) = request.voice_id {
             voice_id.clone()
         } else {
             self.config.voice.clone()
         };
 
-        let response = self
-            .client
-            .post("https://api.openai.com/v1/audio/speech")
-            .header("Authorization", format!("Bearer {}", api_key))
-            .json(&serde_json::json!({
-                "model": self.config.model,
-                "voice": voice,
-                "input": request.text,
-                "response_format": self.config.response_format,
-                "speed": request.speed,
-            }))
+        let mut req = self.client.post(self.endpoint()).json(&serde_json::json!({
+            "model": self.config.model,
+            "voice": voice,
+            "input": request.text,
+            "response_format": self.config.response_format,
+            "speed": request.speed,
+        }));
+        if let Some(auth) = self.auth_header()? {
+            req = req.header("Authorization", auth);
+        }
+
+        let response = req
             .send()
             .await
-            .context("Failed to send request to OpenAI TTS API")?;
+            .context("Failed to send request to OpenAI-compatible TTS API")?;
 
         if !response.status().is_success() {
             let error_text = response.text().await.unwrap_or_default();
@@ -111,5 +126,69 @@ impl VoiceSynthesizer for OpenAiTtsProvider {
             0.000015
         };
         (text_len as f64) * price_per_char
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::default_openai_base_url;
+
+    fn config(base_url: Option<&str>, api_key_env: Option<&str>) -> OpenAiConfig {
+        OpenAiConfig {
+            api_key_env: api_key_env.map(str::to_string),
+            base_url: base_url
+                .map(str::to_string)
+                .unwrap_or_else(default_openai_base_url),
+            model: "tts-1-hd".to_string(),
+            voice: "onyx".to_string(),
+            response_format: "mp3".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_default_endpoint_is_public_api() {
+        let provider = OpenAiTtsProvider::new(config(None, None));
+        assert_eq!(
+            provider.endpoint(),
+            "https://api.openai.com/v1/audio/speech"
+        );
+    }
+
+    #[test]
+    fn test_endpoint_tolerates_trailing_slash() {
+        let provider = OpenAiTtsProvider::new(config(Some("http://127.0.0.1:8080/v1/"), None));
+        assert_eq!(provider.endpoint(), "http://127.0.0.1:8080/v1/audio/speech");
+    }
+
+    #[test]
+    fn test_no_auth_when_api_key_env_absent() {
+        let provider = OpenAiTtsProvider::new(config(None, None));
+        assert_eq!(provider.auth_header().unwrap(), None);
+    }
+
+    #[test]
+    fn test_auth_header_from_env() {
+        const ENV_NAME: &str = "OPENAI_TTS_TEST_TOKEN";
+        std::env::set_var(ENV_NAME, "secret-token");
+        let provider = OpenAiTtsProvider::new(config(None, Some(ENV_NAME)));
+        assert_eq!(
+            provider.auth_header().unwrap(),
+            Some("Bearer secret-token".to_string())
+        );
+        std::env::remove_var(ENV_NAME);
+        assert!(provider.auth_header().is_err());
+    }
+
+    #[test]
+    fn test_serde_defaults_apply_for_local_sidecar() {
+        let json = r#"{
+            "model": "pocket-tts",
+            "voice": "alba",
+            "response_format": "wav"
+        }"#;
+        let cfg: OpenAiConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.base_url, "https://api.openai.com/v1");
+        assert_eq!(cfg.api_key_env, None);
     }
 }

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,23 +1,19 @@
 # GOAP State
 
-**Current Goal**: Implement issue #206 — SynthesisRequest bounds validation + audio.cpp TTS spike
-**Status**: Complete
+**Current Goal**: Config-option TTS integration — OpenAI-compatible `base_url` (default public OpenAI) enabling audio.cpp German sidecar (`OPENAI_TTS_BASE_URL` → PocketTTS alba/wav)
+**Status**: In-Progress
 
 ## Task Graph
-- [x] Task R: Swarm recon — voice crate structure, error types, test conventions, llama feature gating
-- [x] Task B: Branch `fix/synthesis-request-validation` off main + implement validation in `SynthesisRequest::validate()` (orchestrator choke point + goap direct-dispatch guard)
-- [x] Task T: Boundary unit tests — absolute pins per review swarm (R2), multibyte chars test, ordering test
-- [x] Task V: Local verification green under bindgen workaround (fmt, clippy -D warnings, 29 tests)
-- [x] Task S: Swarm adversarial review — FIX_FIRST verdict; R1 (speed range) + R2 (self-referential tests) applied
-- [x] Task P: PR #209 opened, 32/32 checks green on final SHA 04893e2
-- [x] Task M: #209 squash-merged as 076601b; issue #206 auto-closed; FOLLOWUPS/GOAP_STATE updated
-- [x] Task X: audio.cpp CPU spike completed — report in plans/audiocpp-tts-spike.md (RTF ≈ 1.1 CPU German; Phase 2 gated on human listening A/B)
+- [x] Task W1: Web research — Aug 2026 German CPU TTS SOTA (Kokoro 82M MOS 4.44; PocketTTS de MIT cloning WER 1.84; Supertonic-3 de WER 0.66% @ 8.75x RT; audio.cpp serves pocket_tts/supertonic)
+- [x] Task W2: `OpenAiConfig.base_url` (serde default = public API) + optional `api_key_env` (None = no auth header)
+- [x] Task W3: openai.rs endpoint()/auth_header() helpers + conditional Authorization; 5 unit tests incl. serde defaults
+- [x] Task W4: radio_play.rs env wiring — OPENAI_API_KEY → cloud default; else OPENAI_TTS_BASE_URL → German sidecar defaults (pocket-tts/alba/wav)
+- [ ] Task W5: Issue, PR, full green CI on final SHA, merge
+- [ ] Task W6: Spike report Phase-2 addendum + CHANGELOG entry
 
-## Evidence Log
-- Issue #206 contract: sample_rate_hz 8_000..=48_000; speed finite 0.25..=4.0; text ≤ 10_000 chars.
-- Speed range decision: 0.25..=4.0 confirmed by maintainer — sole consumer is openai.rs payload (`"speed": request.speed`, OpenAI documents 0.25–4.0); struct's old `0.5 - 2.0` comment was stale.
-- Review findings logged to FOLLOWUPS.md: all-skipped→exit-0 semantics, zip misalignment, per-provider caps, config-side rate validation.
-- Spike (audio.cpp 0.6.1 @ 62735ea): pocket_tts_german_q8_0 (122 MB), CPU RTF ≈ 1.10, 24 kHz out, ~587 MB RSS. Gotchas: german package needs german-native voice embedding sidecar (english alba.safetensors → instant-EOS 240 ms truncation); not bit-deterministic across runs (±80 ms). Artifacts /tmp/opencode/spike/.
+## History
+- 2026-08-23: #206 complete (PR #209 → 076601b); audio.cpp spike complete (plans/audiocpp-tts-spike.md).
+- 2026-08-23: Started config-option integration per maintainer directives: config option with OpenAI default; German TTS focus; research-backed.
 
 ## Evidence Log
 - Issue #206 requirements: reject sample_rate_hz outside 8_000..=48_000; finite speed 0.25..=4.0; text ≤ 10_000 chars; typed errors; validation once in SynthesisOrchestrator::synthesize pre-dispatch.


### PR DESCRIPTION
## Summary
Closes #211. Makes the TTS engine a config option while keeping real OpenAI as the default.

## Change
- `OpenAiConfig`:
  - new `base_url` (serde default = `https://api.openai.com/v1`) — point at any OpenAI-compatible server
  - `api_key_env: Option<String>` — `None` sends no Authorization header (local sidecars don't need auth)
- `openai.rs`: endpoint derived from `base_url` (trailing-slash tolerant); conditional auth via pure, unit-testable helpers
- `radio_play.rs` env resolution:
  - `OPENAI_API_KEY` set → cloud default (tts-1-hd / onyx / mp3) — unchanged behavior
  - else `OPENAI_TTS_BASE_URL` set → sidecar with **German PocketTTS defaults** (`pocket-tts` / `alba` / `wav`)
  - else provider not registered (as before)

## Research basis (Aug 2026)
- Kokoro-82M remains CPU quality leader (UTMOS ≈ 4.44; already integrated for German via ONNX)
- Kyutai PocketTTS: native German + zero-shot cloning, MIT, WER 1.84 — best local German option with cloning/streaming
- Supertonic-3: best German intelligibility (WER 0.66% @ 8.75× RT)
- audio.cpp serves pocket_tts/supertonic behind `POST /v1/audio/speech`; spike measured RTF ≈ 1.1 CPU German (plans/audiocpp-tts-spike.md)

## Tests
5 new unit tests: default endpoint, trailing-slash handling, no-auth when env absent, bearer from env (+missing → Err), serde defaults for sidecar configs.

## Verification
fmt + clippy `-D warnings` clean (voice, timeline); 32 tests green locally; full CI authoritative.