### PR TITLE
fix(goap): narration alignment + fail-fast on total synthesis failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "serde_json",
  "symphonia 0.6.1",
  "thiserror 2.0.20",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/movie-radio-goap/src/actions.rs
+++ b/crates/movie-radio-goap/src/actions.rs
@@ -213,6 +213,19 @@ impl Action for SynthesizeNarrator {
 
             if let Err(e) = request.validate() {
                 tracing::warn!(i = i + 1, error = %e, "Invalid synthesis request, skipping");
+                ctx.narration_audio.push(None);
+                continue;
+            }
+
+            let cap = provider.capabilities().max_text_length;
+            if script.text.chars().count() > cap {
+                tracing::warn!(
+                    i = i + 1,
+                    cap,
+                    chars = script.text.chars().count(),
+                    "Text exceeds provider cap, skipping"
+                );
+                ctx.narration_audio.push(None);
                 continue;
             }
 
@@ -223,16 +236,26 @@ impl Action for SynthesizeNarrator {
                         samples = audio.samples.len(),
                         "Narration synthesized"
                     );
-                    ctx.narration_audio.push(audio);
+                    ctx.narration_audio.push(Some(audio));
                 }
                 Err(e) => {
                     tracing::warn!(i = i + 1, error = %e, "TTS failed, skipping");
+                    ctx.narration_audio.push(None);
                 }
             }
         }
 
+        if !scripts.is_empty() && ctx.narration_audio.iter().all(Option::is_none) {
+            anyhow::bail!(
+                "all {} narration syntheses failed; check TTS provider configuration \
+                 (e.g. OPENAI_API_KEY / OPENAI_TTS_BASE_URL / MODAL_TTS_ENDPOINT)",
+                scripts.len()
+            );
+        }
+
         info!(
-            count = ctx.narration_audio.len(),
+            count = ctx.narration_audio.iter().filter(|a| a.is_some()).count(),
+            total = scripts.len(),
             "Narration synthesis complete"
         );
         Ok(())
@@ -274,13 +297,8 @@ impl Action for AssembleRadioPlay {
         let scripts = ctx.scripts.as_ref().context("Scripts not generated")?;
 
         let assembler = RadioPlayAssembler::new(ctx.sample_rate, 50, 0.3);
-        let mut narration_segments = Vec::new();
-
-        for (i, (script, audio)) in scripts.iter().zip(ctx.narration_audio.iter()).enumerate() {
-            let segment = assembler.narration_to_segment(script, &audio.samples);
-            narration_segments.push(segment);
-            info!(i = i + 1, "Narration segment prepared");
-        }
+        let narration_segments =
+            build_narration_segments(scripts, &ctx.narration_audio, &assembler);
 
         let radio_play = assembler.assemble(original, &narration_segments)?;
 
@@ -379,4 +397,79 @@ pub fn get_all_actions() -> Vec<Box<dyn Action>> {
         Box::new(VerifyQuality),
         Box::new(ApplyLearnings),
     ]
+}
+
+fn build_narration_segments(
+    scripts: &[crate::narrate::NarrationScript],
+    narration_audio: &[Option<movie_radio_voice::AudioOutput>],
+    assembler: &crate::assemble::RadioPlayAssembler,
+) -> Vec<crate::assemble::NarrationSegment> {
+    scripts
+        .iter()
+        .zip(narration_audio.iter())
+        .filter_map(|(script, audio)| {
+            audio
+                .as_ref()
+                .map(|audio| assembler.narration_to_segment(script, &audio.samples))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::narrate::NarrationScript;
+    use movie_radio_voice::Emotion;
+
+    fn script(gap_start_ms: u64) -> NarrationScript {
+        NarrationScript {
+            gap_start_ms,
+            gap_end_ms: gap_start_ms + 5_000,
+            text: "Hallo Welt".to_string(),
+            emotion: Emotion::Neutral,
+            word_count: 2,
+            duration_ms: 1_000,
+        }
+    }
+
+    fn audio(len_samples: usize) -> Option<movie_radio_voice::AudioOutput> {
+        Some(movie_radio_voice::AudioOutput {
+            samples: vec![0.25; len_samples],
+            sample_rate_hz: 16_000,
+        })
+    }
+
+    #[test]
+    fn test_segments_keep_script_alignment_across_failures() {
+        let scripts = vec![script(1_000), script(2_000), script(3_000)];
+        let narration = vec![audio(800), None, audio(1_600)];
+        let assembler = crate::assemble::RadioPlayAssembler::new(16_000, 50, 0.3);
+
+        let segments = build_narration_segments(&scripts, &narration, &assembler);
+
+        assert_eq!(segments.len(), 2);
+        // First surviving segment belongs to script 0, not shifted by the skip.
+        assert_eq!(segments[0].start_sample, 16_000);
+        assert_eq!(segments[0].samples.len(), 800);
+        // Second surviving segment must pair with script 2 (3_000 ms -> 48_000).
+        assert_eq!(segments[1].start_sample, 48_000);
+        assert_eq!(segments[1].samples.len(), 1_600);
+    }
+
+    #[tokio::test]
+    async fn test_synthesize_narrator_bails_when_all_fail() {
+        std::env::remove_var("MODAL_TTS_ENDPOINT");
+        let mut ctx = crate::PipelineContext::new(
+            std::path::PathBuf::from("movie.mp4"),
+            std::path::PathBuf::from("/tmp/opencode/out.wav"),
+        );
+        ctx.scripts = Some(vec![script(500), script(6_000)]);
+
+        let result = SynthesizeNarrator.execute(&mut ctx).await;
+
+        let err = result.expect_err("total synthesis failure must not pass silently");
+        assert!(err.to_string().contains("all 2 narration syntheses failed"));
+        assert_eq!(ctx.narration_audio.len(), 2);
+        assert!(ctx.narration_audio.iter().all(Option::is_none));
+    }
 }

--- a/crates/movie-radio-goap/src/lib.rs
+++ b/crates/movie-radio-goap/src/lib.rs
@@ -43,7 +43,9 @@ pub struct PipelineContext {
     pub timeline: Option<TimelineOutput>,
     pub gap_analysis: Option<GapAnalysisOutput>,
     pub scripts: Option<Vec<narrate::NarrationScript>>,
-    pub narration_audio: Vec<movie_radio_voice::AudioOutput>,
+    /// Narration audio aligned 1:1 with `scripts` (same order/length);
+    /// `None` marks a script whose synthesis failed.
+    pub narration_audio: Vec<Option<movie_radio_voice::AudioOutput>>,
     pub original_audio: Option<Vec<f32>>,
     pub sample_rate: u32,
 }

--- a/crates/movie-radio-voice/Cargo.toml
+++ b/crates/movie-radio-voice/Cargo.toml
@@ -22,5 +22,8 @@ rand = "0.10"
 qwen_tts = { version = "0.1", default-features = false }
 candle-core = "0.9"
 
+[dev-dependencies]
+tokio.workspace = true
+
 [lints]
 workspace = true

--- a/crates/movie-radio-voice/src/voice/mod.rs
+++ b/crates/movie-radio-voice/src/voice/mod.rs
@@ -179,10 +179,27 @@ impl SynthesisOrchestrator {
 
     pub async fn synthesize(&self, request: &SynthesisRequest) -> Result<AudioOutput> {
         request.validate()?;
+        let text_chars = request.text.chars().count();
         let mut last_err = anyhow::anyhow!("No provider available in fallback chain");
 
         for provider_id in &self.fallback_chain {
             if let Some(provider) = self.providers.get(provider_id) {
+                let cap = provider.capabilities().max_text_length;
+                if text_chars > cap {
+                    tracing::warn!(
+                        provider_id,
+                        cap,
+                        text_chars,
+                        "Text exceeds provider cap; trying next in fallback chain"
+                    );
+                    last_err = anyhow::anyhow!(
+                        "text length {} exceeds provider '{}' cap of {} chars",
+                        text_chars,
+                        provider_id,
+                        cap
+                    );
+                    continue;
+                }
                 match provider.synthesize(request).await {
                     Ok(output) => return Ok(output),
                     Err(e) => {
@@ -282,5 +299,111 @@ mod tests {
             request(&over, 1.0, 192_000).validate(),
             Err(SynthesisValidationError::SampleRateOutOfRange(192_000))
         ));
+    }
+
+    struct FakeProvider {
+        cap: usize,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl VoiceSynthesizer for FakeProvider {
+        async fn synthesize(&self, request: &SynthesisRequest) -> Result<AudioOutput> {
+            if self.fail {
+                anyhow::bail!("injected failure");
+            }
+            Ok(AudioOutput {
+                samples: vec![0.0; 8],
+                sample_rate_hz: request.sample_rate_hz,
+            })
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                supports_emotion: false,
+                supports_voice_cloning: false,
+                supports_streaming: false,
+                max_text_length: self.cap,
+                languages: vec!["de".to_string()],
+                requires_gpu: false,
+            }
+        }
+
+        fn estimate_cost(&self, _text_len: usize) -> f64 {
+            0.0
+        }
+    }
+
+    fn orchestrator_with(
+        providers: Vec<(&str, FakeProvider)>,
+        chain: &[&str],
+    ) -> SynthesisOrchestrator {
+        let mut map = std::collections::HashMap::new();
+        for (id, provider) in providers {
+            map.insert(
+                id.to_string(),
+                Box::new(provider) as Box<dyn VoiceSynthesizer>,
+            );
+        }
+        SynthesisOrchestrator {
+            providers: map,
+            fallback_chain: chain.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_falls_back_when_text_exceeds_provider_cap() {
+        let orchestrator = orchestrator_with(
+            vec![
+                (
+                    "small",
+                    FakeProvider {
+                        cap: 5,
+                        fail: false,
+                    },
+                ),
+                (
+                    "big",
+                    FakeProvider {
+                        cap: 10_000,
+                        fail: false,
+                    },
+                ),
+            ],
+            &["small", "big"],
+        );
+        let output = orchestrator
+            .synthesize(&request("a".repeat(10).as_str(), 1.0, 16_000))
+            .await
+            .expect("second provider must serve the request");
+        assert_eq!(output.sample_rate_hz, 16_000);
+    }
+
+    #[tokio::test]
+    async fn test_errors_when_no_provider_cap_fits() {
+        let orchestrator = orchestrator_with(
+            vec![
+                (
+                    "a",
+                    FakeProvider {
+                        cap: 5,
+                        fail: false,
+                    },
+                ),
+                (
+                    "b",
+                    FakeProvider {
+                        cap: 6,
+                        fail: false,
+                    },
+                ),
+            ],
+            &["a", "b"],
+        );
+        let err = orchestrator
+            .synthesize(&request("abcdefg", 1.0, 16_000))
+            .await
+            .expect_err("no provider can fit the text");
+        assert!(err.to_string().contains("cap of"), "{}", err);
     }
 }

--- a/plans/FOLLOWUPS.md
+++ b/plans/FOLLOWUPS.md
@@ -11,12 +11,17 @@ Each entry includes file path, description, priority, and suggested approach.
 | File/Path | Description | Priority | Suggested Approach |
 |-----------|-------------|----------|-------------------|
 | `src/` (repo root) | Dead legacy tree from pre-workspace layout (`main.rs`, `lib.rs`, `pipeline/`, `voice/`, `verification/`, …). Referenced by **no** package manifest — workspace members are `crates/*` + `benchmarks`; `movie-radio-timeline`'s `[[bin]] path = "src/main.rs"` resolves inside its own crate dir. Contains stale duplicates of live logic (e.g. old `compute_rms`/`compute_zcr`) that can drift silently and mislead readers/tools. | Medium | Delete the root `src/` tree in a dedicated PR after confirming no external references (scripts, CI, docs). |
-| `crates/movie-radio-goap/src/actions.rs:234-238` | When every narration fails TTS/validation, `SynthesizeNarrator::execute` still returns `Ok(())` and the run completes exit-0 with a narration-less play (`narrator_voice_synthesized = true`). The #206 validate guard adds a deterministic trigger (e.g. out-of-range sample rate skips all items with WARN logs only). | Medium | Bail with context when `scripts` is non-empty but `narration_audio` ends empty; or surface a degraded-status flag into the run report. |
-| `crates/movie-radio-goap/src/actions.rs:279` | `scripts.iter().zip(ctx.narration_audio.iter())` misaligns script→audio pairing when a middle item is skipped (pre-existing; failure path had it before #206). | Medium | Track surviving script indices alongside audio, or zip over `(script, Option<Audio>)`. |
-| `crates/movie-radio-voice/src/config.rs:86` (timeline) | `TIMELINE_SAMPLE_RATE` env override validated only as `> 0`; currently never reaches the radio-play synthesis path (hardcoded `AnalysisConfig::default()`), but if wired later an out-of-range value would fail per-request at `SynthesisRequest::validate()` after config acceptance. | Low | Validate 8_000..=48_000 in `apply_env_overrides` for loud early failure. |
-| `crates/movie-radio-voice/src/voice/mod.rs` (capabilities) | Global 10k text cap exceeds per-provider `capabilities().max_text_length` (kokoro 1000, qwen3 2000, orpheus 4000, openai 4096, modal 5000); only ElevenLabs matches 10000. Requests near the global cap will fail late inside providers. | Low | Enforce per-provider cap at dispatch using existing capabilities data. |
+| `crates/movie-radio-timeline/src/config.rs:86` | `TIMELINE_SAMPLE_RATE` env override validated only as `> 0`; currently never reaches the radio-play synthesis path (hardcoded `AnalysisConfig::default()`), but if wired later an out-of-range value would fail per-request at `SynthesisRequest::validate()` after config acceptance. | Low | Validate 8_000..=48_000 in `apply_env_overrides` for loud early failure. |
 
 ## Resolved
+
+| File/Path | Description | Resolution |
+|-----------|-------------|------------|
+| `movie-radio-goap/src/actions.rs` all-skipped semantics | All narrations failing returned `Ok(())` → exit-0 narration-less output | Bail when scripts exist and every synthesis failed |
+| `movie-radio-goap/src/actions.rs:279` zip misalignment | Script→audio pairing shifted after middle-item failure | `narration_audio: Vec<Option<_>>` aligned with scripts by construction; assemble skips `None` |
+| `movie-radio-voice` per-provider text caps | Global 10k cap exceeded provider capabilities, failing late inside providers | Orchestrator checks `capabilities().max_text_length` pre-dispatch and falls through the chain; goap direct-dispatch caller guards too |
+
+## Resolved (historical)
 
 All 4 LOC violations have been resolved by splitting files into submodules:
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,15 +1,15 @@
 # GOAP State
 
-**Current Goal**: Config-option TTS integration — OpenAI-compatible `base_url` (default public OpenAI) enabling audio.cpp German sidecar (`OPENAI_TTS_BASE_URL` → PocketTTS alba/wav)
+**Current Goal**: Fix FOLLOWUPS correctness bugs — narration zip misalignment (structural Option-alignment), all-failed exit-0 degradation, per-provider text caps
 **Status**: In-Progress
 
 ## Task Graph
-- [x] Task W1: Web research — Aug 2026 German CPU TTS SOTA (Kokoro 82M MOS 4.44; PocketTTS de MIT cloning WER 1.84; Supertonic-3 de WER 0.66% @ 8.75x RT; audio.cpp serves pocket_tts/supertonic)
-- [x] Task W2: `OpenAiConfig.base_url` (serde default = public API) + optional `api_key_env` (None = no auth header)
-- [x] Task W3: openai.rs endpoint()/auth_header() helpers + conditional Authorization; 5 unit tests incl. serde defaults
-- [x] Task W4: radio_play.rs env wiring — OPENAI_API_KEY → cloud default; else OPENAI_TTS_BASE_URL → German sidecar defaults (pocket-tts/alba/wav)
-- [ ] Task W5: Issue, PR, full green CI on final SHA, merge
-- [ ] Task W6: Spike report Phase-2 addendum + CHANGELOG entry
+- [x] Task F0: Issue filed; code recon (PipelineContext, assemble pairing, orchestrator loop)
+- [x] Task F1: voice crate — provider cap check in fallback loop before dispatch
+- [x] Task F2: goap lib.rs — `narration_audio: Vec<Option<AudioOutput>>` aligned with scripts
+- [x] Task F3: actions.rs — Some/None pushes, modal cap guard, all-failed bail, assemble skips None
+- [x] Task F4: Tests — fake-provider cap fallback (tokio dev-dep), offline all-failed bail, middle-skip pairing
+- [ ] Task F5: Gates → PR → green CI on final SHA → merge
 
 ## History
 - 2026-08-23: #206 complete (PR #209 → 076601b); audio.cpp spike complete (plans/audiocpp-tts-spike.md).


### PR DESCRIPTION
## Summary
Closes #213. Three correctness fixes from the #206 review follow-ups.

## Change
1. **Structural alignment**: `PipelineContext.narration_audio: Vec<Option<AudioOutput>>` is 1:1 with `scripts` by construction — a middle-item failure can no longer shift every subsequent narration onto the wrong gap (previously `scripts.zip(narration_audio)` paired by success index). Assembly skips `None`.
2. **Fail fast**: when scripts exist and *every* synthesis failed, `SynthesizeNarrator` bails with actionable context instead of returning `Ok(())` and writing a narration-less radio play at exit 0.
3. **Per-provider caps**: orchestrator checks `capabilities().max_text_length` before dispatch, warns, and falls through the chain; the goap direct-dispatch caller (Modal) guards identically.

## Tests
- voice: fake-provider harness — cap-exceeded falls back to next provider; no-fitting-cap errors mentioning the cap (`#[tokio::test]`, new tokio dev-dep)
- goap: middle-skip pairing keeps segments on their own scripts' gaps (exact sample offsets); offline all-fail → bail assertion

## Verification
fmt + clippy `-D warnings` clean; 38 tests green locally; full CI authoritative.