### PR TITLE
fix(timeline): bound TIMELINE_SAMPLE_RATE to supported 8k-48k range

### DIFF
--- a/crates/movie-radio-timeline/src/config.rs
+++ b/crates/movie-radio-timeline/src/config.rs
@@ -53,6 +53,12 @@ pub fn build_analysis_config(
 fn apply_env_overrides(mut cfg: AnalysisConfig) -> Result<AnalysisConfig> {
     if let Ok(v) = env::var("TIMELINE_SAMPLE_RATE") {
         cfg.sample_rate_hz = parse_env_value("TIMELINE_SAMPLE_RATE", &v)?;
+        if !(8_000..=48_000).contains(&cfg.sample_rate_hz) {
+            bail!(
+                "invalid TIMELINE_SAMPLE_RATE={}: must be within 8_000..=48_000 Hz",
+                v
+            );
+        }
     }
     if let Ok(v) = env::var("TIMELINE_FRAME_MS") {
         cfg.frame_ms = parse_env_value("TIMELINE_FRAME_MS", &v)?;

--- a/plans/FOLLOWUPS.md
+++ b/plans/FOLLOWUPS.md
@@ -10,16 +10,17 @@ Each entry includes file path, description, priority, and suggested approach.
 
 | File/Path | Description | Priority | Suggested Approach |
 |-----------|-------------|----------|-------------------|
-| `src/` (repo root) | Dead legacy tree from pre-workspace layout (`main.rs`, `lib.rs`, `pipeline/`, `voice/`, `verification/`, …). Referenced by **no** package manifest — workspace members are `crates/*` + `benchmarks`; `movie-radio-timeline`'s `[[bin]] path = "src/main.rs"` resolves inside its own crate dir. Contains stale duplicates of live logic (e.g. old `compute_rms`/`compute_zcr`) that can drift silently and mislead readers/tools. | Medium | Delete the root `src/` tree in a dedicated PR after confirming no external references (scripts, CI, docs). |
-| `crates/movie-radio-timeline/src/config.rs:86` | `TIMELINE_SAMPLE_RATE` env override validated only as `> 0`; currently never reaches the radio-play synthesis path (hardcoded `AnalysisConfig::default()`), but if wired later an out-of-range value would fail per-request at `SynthesisRequest::validate()` after config acceptance. | Low | Validate 8_000..=48_000 in `apply_env_overrides` for loud early failure. |
+| `tests/` (repo root) | Orphaned integration tests from pre-workspace layout (`voice_integration_tests.rs` references the nonexistent `movie_nonvoice_timeline` package). Not compiled by any workspace member; misleading and unbuildable. | Low | Delete in a dedicated PR after confirming no external references. |
 
 ## Resolved
 
 | File/Path | Description | Resolution |
 |-----------|-------------|------------|
+| `src/` (repo root) | Dead legacy tree from pre-workspace layout (`main.rs`, `lib.rs`, `pipeline/`, `voice/`, `verification/`, …). Referenced by **no** package manifest — workspace members are `crates/*` + `benchmarks`. Contains stale duplicates of live logic (e.g. old `compute_rms`/`compute_zcr`). | Deleted (70 files, ~12k LOC); verified no references in scripts/, CI, benchmarks, docs |
 | `movie-radio-goap/src/actions.rs` all-skipped semantics | All narrations failing returned `Ok(())` → exit-0 narration-less output | Bail when scripts exist and every synthesis failed |
 | `movie-radio-goap/src/actions.rs:279` zip misalignment | Script→audio pairing shifted after middle-item failure | `narration_audio: Vec<Option<_>>` aligned with scripts by construction; assemble skips `None` |
 | `movie-radio-voice` per-provider text caps | Global 10k cap exceeded provider capabilities, failing late inside providers | Orchestrator checks `capabilities().max_text_length` pre-dispatch and falls through the chain; goap direct-dispatch caller guards too |
+| `crates/movie-radio-timeline/src/config.rs` env rate validation | `TIMELINE_SAMPLE_RATE` accepted any non-zero value; out-of-range surfaced only per-request later | Range-checked 8_000..=48_000 in `apply_env_overrides` |
 
 ## Resolved (historical)
 

--- a/plans/audiocpp-tts-spike.md
+++ b/plans/audiocpp-tts-spike.md
@@ -3,6 +3,20 @@
 **Date**: 2026-08-23 · **Spike branch**: none (all artifacts in `/tmp/opencode/`, repo untouched)
 **Question**: Is audio.cpp (0xShug0/audio.cpp) a better TTS vehicle than our in-process providers?
 
+## Phase 2 addendum — German A/B set (same day, second run)
+
+Incremental build adding supertonic: +60 s. **No 24-layer German PocketTTS exists** — `model_specs/pocket_tts.json` and the HF package tree carry only q8_0/bf16 per language (`_24l` is French-only upstream); bf16 downloaded as best-available higher-quality German variant.
+
+| Config | Package | RTF (CPU) | Notes |
+|---|---|---|---|
+| pocket_tts de q8_0 (122 MB) | baseline | **1.11–1.18** | unchanged from first run |
+| pocket_tts de bf16 (209 MB) | quality candidate | 1.17–1.29 | same distilled arch, higher precision |
+| supertonic de s4 speed (454 MB, 44.1 kHz) | not recommended | 0.71–0.95 | ⚠ clipping on longer lines |
+| supertonic de s8 default | quality candidate | 1.25–1.61 | sweet spot |
+| supertonic de s32 quality | reference | 4.5–6.0 | offline only |
+
+Listening set: `/tmp/opencode/spike/ab/` — compare `pocket_bf16` vs `pocket_q8`, and `super_s8` vs `super_s32`. Supertonic duration predictor is step-independent (identical durations across step counts). No seed flag for pocket_tts; supertonic pinned `--seed 1234`.
+
 ## Verdict
 
 **Promising for scoped adoption — proceed to Phase 2 design only after human listening test.**


### PR DESCRIPTION
## Summary
Closes the last code item of #217. Out-of-range `TIMELINE_SAMPLE_RATE` env overrides now fail loudly at config validation instead of surfacing per-request at synthesis time.

## Also lands (docs)
- `plans/audiocpp-tts-spike.md`: Phase 2 addendum — German A/B measurements (PocketTTS bf16 vs q8, Supertonic-de step sweep s4/s8/s32, RTF + clipping warning on s4; **no 24-layer German pack exists** — bf16 is best available)
- `plans/FOLLOWUPS.md`: root `src/` removal, rate validation marked resolved; orphaned root `tests/` logged as new low-priority row
- GOAP state closeout

Code change is 5 lines in `apply_env_overrides`; docs-only otherwise.