### PR TITLE
fix(voice,goap): harden TTS WAV parsing and eliminate panic paths in retry/gap code

### DIFF
--- a/crates/movie-radio-goap/src/gaps.rs
+++ b/crates/movie-radio-goap/src/gaps.rs
@@ -45,7 +45,7 @@ impl GapIdentifier {
                 continue;
             }
 
-            let duration = seg.end_ms - seg.start_ms;
+            let duration = seg.end_ms.saturating_sub(seg.start_ms);
             let mut confidence = 0.0;
             let mut reasons = Vec::new();
 
@@ -144,9 +144,14 @@ impl GapIdentifier {
         confidence: &mut f32,
         reasons: &mut Vec<String>,
     ) {
-        let has_speech_before = index > 0 && segments[index - 1].kind == SegmentKind::Speech;
-        let has_speech_after =
-            index < segments.len() - 1 && segments[index + 1].kind == SegmentKind::Speech;
+        let has_speech_before = index > 0
+            && segments
+                .get(index.saturating_sub(1))
+                .is_some_and(|s| s.kind == SegmentKind::Speech);
+        let has_speech_after = index < segments.len().saturating_sub(1)
+            && segments
+                .get(index + 1)
+                .is_some_and(|s| s.kind == SegmentKind::Speech);
 
         if has_speech_before && has_speech_after {
             *confidence += 0.2;
@@ -162,7 +167,7 @@ impl GapIdentifier {
         confidence: &mut f32,
         reasons: &mut Vec<String>,
     ) {
-        if index > 0 && index < segments.len() - 1 {
+        if index > 0 && index < segments.len().saturating_sub(1) {
             let prev = &segments[index - 1];
             let next = &segments[index + 1];
 
@@ -403,5 +408,48 @@ mod tests {
         let mut r = Vec::new();
         id.analyze_subtitle_gap(1200, 1800, &None, &mut c, &mut r);
         assert_eq!(c, 0.0);
+    }
+
+    #[test]
+    fn test_empty_segments_slice_non_panic() {
+        let id = GapIdentifier::default();
+        let mut c = 0.0;
+        let mut r = Vec::new();
+
+        id.analyze_dialogue_proximity(0, &[], &mut c, &mut r);
+        assert_eq!(c, 0.0);
+
+        id.analyze_audio_environment_change(0, &[], &mut c, &mut r);
+        assert_eq!(c, 0.0);
+
+        let timeline = TimelineOutput {
+            file: "empty.mp3".to_string(),
+            analysis_sample_rate: 16000,
+            frame_ms: 20,
+            segments: vec![],
+        };
+        let res = id.identify_gaps(&timeline, None).unwrap();
+        assert!(res.gaps.is_empty());
+    }
+
+    #[test]
+    fn test_inverted_segment_non_panic() {
+        let timeline = TimelineOutput {
+            file: "inverted.mp3".to_string(),
+            analysis_sample_rate: 16000,
+            frame_ms: 20,
+            segments: vec![Segment {
+                start_ms: 5000,
+                end_ms: 1000,
+                kind: SegmentKind::NonVoice,
+                confidence: 1.0,
+                tags: vec![],
+                prompt: None,
+            }],
+        };
+
+        let id = GapIdentifier::default();
+        let res = id.identify_gaps(&timeline, None).unwrap();
+        assert!(res.gaps.is_empty());
     }
 }

--- a/crates/movie-radio-voice/src/voice/modal.rs
+++ b/crates/movie-radio-voice/src/voice/modal.rs
@@ -51,16 +51,7 @@ impl VoiceSynthesizer for ModalTtsProvider {
             .await
             .context("Failed to read Modal response bytes")?;
 
-        if bytes.len() < 44 {
-            anyhow::bail!("Modal response too short to be a valid WAV");
-        }
-
-        let pcm_data = &bytes[44..];
-        let mut samples = Vec::with_capacity(pcm_data.len() / 2);
-        for chunk in pcm_data.as_chunks::<2>().0 {
-            let s = i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32;
-            samples.push(s);
-        }
+        let samples = parse_pcm16_mono_wav(&bytes).context("Failed to parse Modal WAV response")?;
 
         Ok(AudioOutput {
             samples,
@@ -81,5 +72,180 @@ impl VoiceSynthesizer for ModalTtsProvider {
 
     fn estimate_cost(&self, text_len: usize) -> f64 {
         (text_len as f64) * 0.0000006
+    }
+}
+
+/// Parses a RIFF/WAVE byte buffer containing 16-bit PCM mono audio.
+///
+/// Validates container signatures and format metadata (`fmt ` chunk) and locates
+/// the `data` chunk to extract normalized `f32` samples.
+fn parse_pcm16_mono_wav(bytes: &[u8]) -> Result<Vec<f32>> {
+    if bytes.len() < 12 {
+        anyhow::bail!("Modal response too short to be a valid WAV");
+    }
+
+    if &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+        anyhow::bail!("Invalid WAV container: missing RIFF/WAVE header");
+    }
+
+    let mut cursor = 12;
+    let mut fmt_checked = false;
+    let mut pcm_data: Option<&[u8]> = None;
+
+    while cursor + 8 <= bytes.len() {
+        let chunk_id = &bytes[cursor..cursor + 4];
+        let chunk_size = u32::from_le_bytes([
+            bytes[cursor + 4],
+            bytes[cursor + 5],
+            bytes[cursor + 6],
+            bytes[cursor + 7],
+        ]) as usize;
+        cursor += 8;
+
+        if cursor + chunk_size > bytes.len() {
+            anyhow::bail!("Invalid WAV chunk bounds: chunk exceeds response buffer");
+        }
+
+        let chunk_body = &bytes[cursor..cursor + chunk_size];
+
+        if chunk_id == b"fmt " {
+            if chunk_size < 16 {
+                anyhow::bail!("Invalid WAV fmt chunk size: must be at least 16 bytes");
+            }
+            let audio_format = u16::from_le_bytes([chunk_body[0], chunk_body[1]]);
+            let num_channels = u16::from_le_bytes([chunk_body[2], chunk_body[3]]);
+            let bits_per_sample = u16::from_le_bytes([chunk_body[14], chunk_body[15]]);
+
+            if audio_format != 1 {
+                anyhow::bail!(
+                    "Unsupported WAV format: expected uncompressed PCM (1), got {}",
+                    audio_format
+                );
+            }
+            if num_channels != 1 {
+                anyhow::bail!(
+                    "Unsupported WAV channel count: expected mono (1), got {}",
+                    num_channels
+                );
+            }
+            if bits_per_sample != 16 {
+                anyhow::bail!(
+                    "Unsupported WAV bit depth: expected 16-bit, got {}",
+                    bits_per_sample
+                );
+            }
+            fmt_checked = true;
+        } else if chunk_id == b"data" {
+            pcm_data = Some(chunk_body);
+            break;
+        }
+
+        // Chunk sizes in RIFF are padded to word boundaries (2 bytes)
+        let pad = if chunk_size % 2 == 1 { 1 } else { 0 };
+        cursor += chunk_size + pad;
+    }
+
+    if !fmt_checked {
+        anyhow::bail!("Invalid WAV container: missing or malformed fmt chunk");
+    }
+
+    let pcm = match pcm_data {
+        Some(data) => data,
+        None => anyhow::bail!("Invalid WAV container: missing data chunk"),
+    };
+
+    let mut samples = Vec::with_capacity(pcm.len() / 2);
+    for chunk in pcm.chunks_exact(2) {
+        let s = i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32;
+        samples.push(s);
+    }
+
+    Ok(samples)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_valid_wav(samples_i16: &[i16]) -> Vec<u8> {
+        let pcm_bytes: Vec<u8> = samples_i16.iter().flat_map(|s| s.to_le_bytes()).collect();
+        let data_size = pcm_bytes.len() as u32;
+        let riff_size = 36 + data_size;
+
+        let mut header = Vec::new();
+        header.extend_from_slice(b"RIFF");
+        header.extend_from_slice(&riff_size.to_le_bytes());
+        header.extend_from_slice(b"WAVE");
+
+        header.extend_from_slice(b"fmt ");
+        header.extend_from_slice(&(16u32.to_le_bytes())); // chunk size
+        header.extend_from_slice(&(1u16.to_le_bytes())); // PCM format
+        header.extend_from_slice(&(1u16.to_le_bytes())); // mono
+        header.extend_from_slice(&(16000u32.to_le_bytes())); // sample rate
+        header.extend_from_slice(&(32000u32.to_le_bytes())); // byte rate
+        header.extend_from_slice(&(2u16.to_le_bytes())); // block align
+        header.extend_from_slice(&(16u16.to_le_bytes())); // bits per sample
+
+        header.extend_from_slice(b"data");
+        header.extend_from_slice(&data_size.to_le_bytes());
+        header.extend_from_slice(&pcm_bytes);
+
+        header
+    }
+
+    #[test]
+    fn test_parse_valid_wav() {
+        let raw_samples = vec![0i16, 16384, -16384, i16::MAX];
+        let wav_bytes = make_valid_wav(&raw_samples);
+
+        let parsed = parse_pcm16_mono_wav(&wav_bytes).unwrap();
+        assert_eq!(parsed.len(), 4);
+        assert_eq!(parsed[0], 0.0);
+        assert!((parsed[1] - (16384.0 / i16::MAX as f32)).abs() < 1e-5);
+        assert!((parsed[2] - (-16384.0 / i16::MAX as f32)).abs() < 1e-5);
+        assert_eq!(parsed[3], 1.0);
+    }
+
+    #[test]
+    fn test_parse_sub_44_byte_body_err() {
+        let short_bytes = vec![0u8; 20];
+        let err = parse_pcm16_mono_wav(&short_bytes).unwrap_err();
+        assert!(err.to_string().contains("Invalid WAV container"));
+    }
+
+    #[test]
+    fn test_parse_invalid_riff_header() {
+        let mut wav_bytes = make_valid_wav(&[100, 200]);
+        wav_bytes[0..4].copy_from_slice(b"FORM");
+        let err = parse_pcm16_mono_wav(&wav_bytes).unwrap_err();
+        assert!(err.to_string().contains("missing RIFF/WAVE header"));
+    }
+
+    #[test]
+    fn test_parse_non_pcm_wav() {
+        let mut wav_bytes = make_valid_wav(&[100, 200]);
+        // Modify audio_format to 3 (IEEE float)
+        wav_bytes[20..22].copy_from_slice(&(3u16.to_le_bytes()));
+        let err = parse_pcm16_mono_wav(&wav_bytes).unwrap_err();
+        assert!(err.to_string().contains("expected uncompressed PCM"));
+    }
+
+    #[test]
+    fn test_parse_stereo_wav() {
+        let mut wav_bytes = make_valid_wav(&[100, 200]);
+        // Modify num_channels to 2
+        wav_bytes[22..24].copy_from_slice(&(2u16.to_le_bytes()));
+        let err = parse_pcm16_mono_wav(&wav_bytes).unwrap_err();
+        assert!(err.to_string().contains("expected mono"));
+    }
+
+    #[test]
+    fn test_parse_truncated_chunk_bounds() {
+        let mut wav_bytes = make_valid_wav(&[100, 200]);
+        // Truncate the buffer in the middle of the data chunk
+        wav_bytes.pop();
+        wav_bytes.pop();
+        let err = parse_pcm16_mono_wav(&wav_bytes).unwrap_err();
+        assert!(err.to_string().contains("chunk exceeds response buffer"));
     }
 }

--- a/crates/movie-radio-voice/src/voice/modal.rs
+++ b/crates/movie-radio-voice/src/voice/modal.rs
@@ -75,17 +75,53 @@ impl VoiceSynthesizer for ModalTtsProvider {
     }
 }
 
+/// Validates that a `fmt ` chunk contains 16-bit mono PCM audio settings.
+fn validate_fmt_chunk(chunk_body: &[u8]) -> Result<()> {
+    if chunk_body.len() < 16 {
+        anyhow::bail!("Invalid WAV fmt chunk size: must be at least 16 bytes");
+    }
+    let audio_format = u16::from_le_bytes([chunk_body[0], chunk_body[1]]);
+    let num_channels = u16::from_le_bytes([chunk_body[2], chunk_body[3]]);
+    let bits_per_sample = u16::from_le_bytes([chunk_body[14], chunk_body[15]]);
+
+    if audio_format != 1 {
+        anyhow::bail!(
+            "Unsupported WAV format: expected uncompressed PCM (1), got {}",
+            audio_format
+        );
+    }
+    if num_channels != 1 {
+        anyhow::bail!(
+            "Unsupported WAV channel count: expected mono (1), got {}",
+            num_channels
+        );
+    }
+    if bits_per_sample != 16 {
+        anyhow::bail!(
+            "Unsupported WAV bit depth: expected 16-bit, got {}",
+            bits_per_sample
+        );
+    }
+    Ok(())
+}
+
+/// Converts raw 16-bit LE PCM byte slice to normalized `f32` audio samples.
+fn decode_pcm16_samples(pcm: &[u8]) -> Vec<f32> {
+    let mut samples = Vec::with_capacity(pcm.len() / 2);
+    for chunk in pcm.as_chunks::<2>().0 {
+        let s = i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32;
+        samples.push(s);
+    }
+    samples
+}
+
 /// Parses a RIFF/WAVE byte buffer containing 16-bit PCM mono audio.
 ///
 /// Validates container signatures and format metadata (`fmt ` chunk) and locates
 /// the `data` chunk to extract normalized `f32` samples.
 fn parse_pcm16_mono_wav(bytes: &[u8]) -> Result<Vec<f32>> {
-    if bytes.len() < 12 {
-        anyhow::bail!("Modal response too short to be a valid WAV");
-    }
-
-    if &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
-        anyhow::bail!("Invalid WAV container: missing RIFF/WAVE header");
+    if bytes.len() < 12 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+        anyhow::bail!("Invalid WAV container: missing or short RIFF/WAVE header");
     }
 
     let mut cursor = 12;
@@ -108,36 +144,16 @@ fn parse_pcm16_mono_wav(bytes: &[u8]) -> Result<Vec<f32>> {
 
         let chunk_body = &bytes[cursor..cursor + chunk_size];
 
-        if chunk_id == b"fmt " {
-            if chunk_size < 16 {
-                anyhow::bail!("Invalid WAV fmt chunk size: must be at least 16 bytes");
+        match chunk_id {
+            b"fmt " => {
+                validate_fmt_chunk(chunk_body)?;
+                fmt_checked = true;
             }
-            let audio_format = u16::from_le_bytes([chunk_body[0], chunk_body[1]]);
-            let num_channels = u16::from_le_bytes([chunk_body[2], chunk_body[3]]);
-            let bits_per_sample = u16::from_le_bytes([chunk_body[14], chunk_body[15]]);
-
-            if audio_format != 1 {
-                anyhow::bail!(
-                    "Unsupported WAV format: expected uncompressed PCM (1), got {}",
-                    audio_format
-                );
+            b"data" => {
+                pcm_data = Some(chunk_body);
+                break;
             }
-            if num_channels != 1 {
-                anyhow::bail!(
-                    "Unsupported WAV channel count: expected mono (1), got {}",
-                    num_channels
-                );
-            }
-            if bits_per_sample != 16 {
-                anyhow::bail!(
-                    "Unsupported WAV bit depth: expected 16-bit, got {}",
-                    bits_per_sample
-                );
-            }
-            fmt_checked = true;
-        } else if chunk_id == b"data" {
-            pcm_data = Some(chunk_body);
-            break;
+            _ => {}
         }
 
         // Chunk sizes in RIFF are padded to word boundaries (2 bytes)
@@ -149,18 +165,8 @@ fn parse_pcm16_mono_wav(bytes: &[u8]) -> Result<Vec<f32>> {
         anyhow::bail!("Invalid WAV container: missing or malformed fmt chunk");
     }
 
-    let pcm = match pcm_data {
-        Some(data) => data,
-        None => anyhow::bail!("Invalid WAV container: missing data chunk"),
-    };
-
-    let mut samples = Vec::with_capacity(pcm.len() / 2);
-    for chunk in pcm.chunks_exact(2) {
-        let s = i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32;
-        samples.push(s);
-    }
-
-    Ok(samples)
+    let pcm = pcm_data.context("Invalid WAV container: missing data chunk")?;
+    Ok(decode_pcm16_samples(pcm))
 }
 
 #[cfg(test)]
@@ -218,7 +224,7 @@ mod tests {
         let mut wav_bytes = make_valid_wav(&[100, 200]);
         wav_bytes[0..4].copy_from_slice(b"FORM");
         let err = parse_pcm16_mono_wav(&wav_bytes).unwrap_err();
-        assert!(err.to_string().contains("missing RIFF/WAVE header"));
+        assert!(err.to_string().contains("missing or short RIFF/WAVE header"));
     }
 
     #[test]

--- a/crates/movie-radio-voice/src/voice/modal.rs
+++ b/crates/movie-radio-voice/src/voice/modal.rs
@@ -224,7 +224,9 @@ mod tests {
         let mut wav_bytes = make_valid_wav(&[100, 200]);
         wav_bytes[0..4].copy_from_slice(b"FORM");
         let err = parse_pcm16_mono_wav(&wav_bytes).unwrap_err();
-        assert!(err.to_string().contains("missing or short RIFF/WAVE header"));
+        assert!(err
+            .to_string()
+            .contains("missing or short RIFF/WAVE header"));
     }
 
     #[test]

--- a/crates/movie-radio-voice/src/voice/openai.rs
+++ b/crates/movie-radio-voice/src/voice/openai.rs
@@ -88,12 +88,19 @@ impl OpenAiTtsProvider {
                 }
             }
         }
-        Err(last_err.expect("retry loop runs at least once")).with_context(|| {
-            format!(
+        match last_err {
+            Some(err) => Err(err).with_context(|| {
+                format!(
+                    "TTS endpoint unreachable after {} attempts: {}",
+                    MAX_CONNECT_ATTEMPTS, endpoint
+                )
+            }),
+            None => anyhow::bail!(
                 "TTS endpoint unreachable after {} attempts: {}",
-                MAX_CONNECT_ATTEMPTS, endpoint
-            )
-        })
+                MAX_CONNECT_ATTEMPTS,
+                endpoint
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
Bundle of three correctness fixes in movie-radio-voice and movie-radio-goap:
1. openai.rs: Eliminated the non-test `.expect()` in the retry loop, replacing it with `match last_err`.
2. modal.rs: Added `parse_pcm16_mono_wav` to strictly validate RIFF/WAVE headers, fmt chunks (16-bit mono PCM), chunk bounds, and sub-44-byte responses before parsing samples.
3. gaps.rs: Applied `saturating_sub` and `is_some_and` bounds checking to eliminate potential underflows on empty or inverted inputs.

Fixes #226

---
*PR created automatically by Jules for task [16640866675978518378](https://jules.google.com/task/16640866675978518378) started by @d-oit*