### PR TITLE
recovery: restore PR #223 content reverted by stale-base direct pushes

### DIFF
--- a/crates/movie-radio-pipeline/src/pipeline/speech_evidence.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/speech_evidence.rs
@@ -40,11 +40,12 @@ fn average_frame_stats(frames: &[Frame], frame_ms: u32, start_ms: u64, end_ms: u
         return AvgStats::default();
     }
     let frame_ms = frame_ms.max(1) as u64;
-    let start_idx = (start_ms / frame_ms) as usize;
-    let end_idx = (end_ms.div_ceil(frame_ms) as usize)
-        .min(frames.len())
-        .max(start_idx + 1);
-    let slice = &frames[start_idx.min(frames.len().saturating_sub(1))..end_idx];
+    let mut start_idx = (start_ms / frame_ms) as usize;
+    if start_idx >= frames.len() {
+        start_idx = frames.len().saturating_sub(1);
+    }
+    let end_idx = (end_ms.div_ceil(frame_ms) as usize).clamp(start_idx + 1, frames.len());
+    let slice = &frames[start_idx..end_idx];
     let n = slice.len().max(1) as f32;
 
     AvgStats {
@@ -112,5 +113,18 @@ mod tests {
         let kept = filter_implausible_speech_segments(&segments, &frames, 500);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0].start_ms, 1000);
+    }
+
+    #[test]
+    fn out_of_range_segment_timestamps_do_not_panic() {
+        let segments = vec![speech_segment(60_000, 61_000, 0.6)];
+        let frames = vec![frame(0.12, 0.2, 4.0, 1800.0, 0.2, 0.2)];
+        let kept = filter_implausible_speech_segments(&segments, &frames, 20);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].start_ms, 60_000);
+
+        let empty_frames: Vec<Frame> = Vec::new();
+        let kept_empty = filter_implausible_speech_segments(&segments, &empty_frames, 20);
+        assert_eq!(kept_empty.len(), 1);
     }
 }

--- a/plans/050-status-report/GAPS.md
+++ b/plans/050-status-report/GAPS.md
@@ -2,30 +2,30 @@
 
 Gaps between the current specification and the implemented runtime behavior.
 
-**Updated:** 2026-06-23
+**Updated:** 2026-08-25
 
-## Voice Synthesis: Most Providers Return Silence
+## Voice Synthesis: Provider Status & Quality Caveats
 
 **Affected:** Radio-play production readiness
 **Location:** `crates/movie-radio-voice/src/voice/`
 
 **Spec:** All configured TTS providers should produce actual audio output.
 
-**Actual:** Modal (PR #110) and ElevenLabs now produce real audio. OpenAI TTS is now implemented. The remaining providers (Kokoro, Orpheus, Qwen3, PocketTts) have correct trait implementations, config structs, and capability declarations, but their `synthesize()` methods return silence or zero-filled buffers.
+**Actual:** Refreshed after workspace-wide analysis (`plans/130-improvement-analysis-2026-08-25.md`). All HTTP providers (Modal, ElevenLabs, OpenAI) produce real audio. Local inference landed for Qwen3 (candle), Kokoro (ONNX Runtime), and Orpheus (llama.cpp token loop), with quality caveats below. PocketTts remains a silence stub and is recommended for removal.
 
 **Provider Status:**
 
 | Provider | Infrastructure | Real Synthesis | Blocker |
 |----------|---------------|----------------|---------|
-| Modal | Complete | Yes | None |
+| Modal | Complete | Yes (no RIFF validation — see FOLLOWUPS) | Header hardening |
 | ElevenLabs | Complete (HTTP) | Yes (MP3 decode via symphonia) | None |
-| OpenAI | Complete (HTTP) | Yes (MP3 decode via symphonia) | None |
-| Kokoro | Complete (ONNX download) | No (silence) | ONNX inference not wired to output |
-| Orpheus | Partial (emotion tags) | No (silence) | Needs `llama-cpp-2` integration |
-| Qwen3 | Partial (emotion prompts) | No (silence) | Needs model inference |
-| PocketTts | None | No (silence) | Fully stubbed |
+| OpenAI | Complete (HTTP) | Yes (MP3 decode via symphonia) | One `.expect()` cleanup (see FOLLOWUPS) |
+| Kokoro | Complete (ONNX download) | Partial — real ONNX inference, but tokenization maps raw codepoints instead of eSD phoneme vocabulary | Phoneme tokenizer; acoustic output unverified |
+| Orpheus | Complete (llama.cpp inference) | Partial — real token generation; SNAC→PCM decoding falls back to synthetic tones | SNAC vocoder decode |
+| Qwen3 | Complete (candle inference) | Yes (CUDA→CPU fallback) | None |
+| PocketTts | Config-only | No (silence stub, falsely advertises cloning/streaming caps) | Recommended for removal |
 
-**Fix:** Prioritize local providers (Kokoro ONNX, Orpheus GGUF, Qwen3) for offline capability.
+**Fix:** Complete Kokoro phoneme tokenization and Orpheus SNAC decode for offline capability; remove PocketTts. Consider feature-gating local-inference dependencies (`local-tts` umbrella) so default builds skip the llama.cpp/candle/ort compile cost.
 
 ## GOAP Orchestrator Executes Real Pipeline Stages
 

--- a/plans/060-next-features/PHASE-06-new-capabilities.md
+++ b/plans/060-next-features/PHASE-06-new-capabilities.md
@@ -2,7 +2,7 @@
 
 New features to extend the pipeline beyond its current scope.
 
-**Updated:** 2026-06-22
+**Updated:** 2026-08-25
 
 ## 6.0 Production Evaluation Correctness First
 
@@ -89,7 +89,7 @@ speech/non-speech decisions.
 - Directly addresses TRIZ-001 (speech vs. music contradiction)
 - No ML required; stays within deterministic constraints
 
-## 6.9 Radio-Play Pipeline Integration 🔄 IN PROGRESS
+## 6.9 Radio-Play Pipeline Integration ✅ COMPLETE
 
 Wire the implemented GOAP modules into an end-to-end radio-play CLI command.
 
@@ -97,18 +97,19 @@ Wire the implemented GOAP modules into an end-to-end radio-play CLI command.
 - ✅ Narration text generation (template-based German in `movie-radio-goap/src/narrate.rs`)
 - ✅ Audio assembly (crossfade + ducking in `movie-radio-goap/src/assemble.rs`)
 - ✅ Modal.com TTS provider (real audio output)
-- 🔄 Wire GOAP orchestrator to execute real pipeline stages
-- 🔄 Wire radio-play CLI handler to full pipeline (gap → narrate → TTS → assemble → output)
-- 🔄 Add MP3 decode for ElevenLabs response
-- ❌ Implement local TTS inference (Kokoro ONNX, Orpheus GGUF, Qwen3)
+- ✅ Wire GOAP orchestrator to execute real pipeline stages
+- ✅ Wire radio-play CLI handler to full pipeline (gap → narrate → TTS → assemble → output)
+- ✅ Add MP3 decode for ElevenLabs response (symphonia; reused by OpenAI-compatible provider)
+- ✅ Implement local TTS inference (Qwen3 via candle; Kokoro via ONNX Runtime; Orpheus via llama.cpp — remaining quality caveats tracked in §6.10)
 
 ## 6.10 Voice Provider Hardening
 
 Complete the voice synthesis providers for production use.
 
-- Add MP3 decode for ElevenLabs (symphonia or minimp3)
-- Wire Kokoro ONNX inference to output (currently returns silence)
-- Implement Orpheus GGUF loading via llama-cpp-2
-- Implement Qwen3 model inference
-- Add OpenAI TTS REST client
+- ✅ Add MP3 decode for ElevenLabs (symphonia; `decode_audio_bytes`)
+- 🔄 Wire Kokoro ONNX inference to output — inference is live, but tokenization maps raw codepoints instead of eSD phoneme vocabulary, so acoustic output is unverified (see plans/130-improvement-analysis-2026-08-25.md §B1)
+- 🔄 Implement Orpheus GGUF loading via llama-cpp-2 — token inference works; SNAC→PCM decode still falls back to synthetic tones
+- ✅ Implement Qwen3 model inference (candle-based, CUDA→CPU fallback)
+- ✅ Add OpenAI TTS REST client (registered in `SynthesisOrchestrator` fallback chain)
 - Ensure voice consistency across provider switching
+- Remove PocketTts stub (returns silence, falsely advertises capabilities — see plans/130-improvement-analysis-2026-08-25.md §B2)

--- a/plans/130-improvement-analysis-2026-08-25.md
+++ b/plans/130-improvement-analysis-2026-08-25.md
@@ -1,0 +1,140 @@
+# Improvement Analysis — 2026-08-25
+
+Workspace-wide analysis covering correctness bugs, architecture debt, infrastructure gaps,
+test coverage, and new-feature candidates.
+
+**Method:** Full sweep of `crates/`, `scripts/`, `.github/workflows/`, and `benchmarks/`
+(~15.7k LOC across 10 crates), cross-referenced against `GOAP_STATE.md`, `FOLLOWUPS.md`,
+`050-status-report/GAPS.md`, `060-next-features/PHASE-06-new-capabilities.md`, and
+`100-radio-play-95/ROADMAP.md` to exclude already-tracked work. Baseline: zero open
+issues/PRs, FOLLOWUPS open = none, current GOAP goal complete.
+
+---
+
+## A. Correctness Fixes
+
+### A1 (P0): Slice-index panic in speech evidence filter
+- **Location:** `crates/movie-radio-pipeline/src/pipeline/speech_evidence.rs:43-47`
+- **Bug:** `end_idx = (...).min(frames.len()).max(start_idx + 1)` — when a segment
+  timestamp maps beyond the decoded frame count (`start_idx >= frames.len()`),
+  `end_idx > frames.len()` and the subsequent slice panics.
+- **Fix:** Mirror the clamp pattern from the twin implementation in
+  `pipeline/segmenter/confidence.rs:53-58`: `end_idx.clamp(start_idx + 1, frames.len())`.
+- **Test:** Regression case with segment timestamps exceeding total decoded duration.
+
+### A2 (P1): Library-code `.expect()` violation
+- **Location:** `crates/movie-radio-voice/src/voice/openai.rs:91`
+- **Bug:** `last_err.expect("retry loop runs at least once")` — the only non-test
+  `expect()` in library code; violates the AGENTS.md no-unwrap rule. All other 87 raw
+  hits live inside `#[cfg(test)]` modules.
+- **Fix:** Propagate via typed error instead of panicking (invariant is real but must
+  not have a panic path).
+
+### A3 (P2): Defensive guards in gap scoring
+- **Location:** `crates/movie-radio-goap/src/gaps.rs:48,149,165`
+- **Bug:** `segments.len() - 1` underflows on an empty slice; `seg.end_ms -
+  seg.start_ms` underflows on inverted segments. Unreachable via current call sites,
+  but the private API accepts arbitrary inputs.
+- **Fix:** Bail on empty slices; saturating subtraction for durations.
+
+### A4 (P2): Modal WAV parsing lacks container validation
+- **Location:** `crates/movie-radio-voice/src/voice/modal.rs:54-63`
+- **Bug:** Response parsed by blindly skipping a 44-byte header, assuming
+  little-endian i16 mono PCM; only `len >= 44` is validated.
+- **Fix:** Validate RIFF/WAVE magic, format tag, and channel count before conversion;
+  fall through the provider chain on mismatch.
+
+## B. Architecture Debt
+
+### B1: Feature-gate local TTS inference dependencies
+- **Location:** `crates/movie-radio-voice/Cargo.toml:17,20,23-24`
+- llama-cpp-2 (full llama.cpp C++ build), candle-core (+nn/transformers), qwen_tts,
+  and ort are unconditional → every workspace-wide `cargo build/test/clippy` pays the
+  full native compile cost.
+- **Proposal:** HTTP providers (openai/modal/elevenlabs) in the default build; gate
+  native deps behind per-provider features (`kokoro`, `orpheus`, `qwen3`) or one
+  `local-tts` umbrella feature.
+- **Related caveat:** Kokoro tokenization (`kokoro.rs:128-131`) maps raw codepoints to
+  token IDs instead of an eSD phoneme vocabulary — acoustically suspect even though
+  ONNX inference is live. Fix alongside B1.
+- **Related:** `ort = "2.0.0-rc.9"` is a pre-release pin in a production decode path;
+  track its stable release.
+
+### B2: Remove PocketTts stub (recommended)
+- **Location:** `crates/movie-radio-voice/src/voice/pockettts.rs:19-31`
+- Returns one second of silence ignoring request text while capabilities falsely
+  advertise voice cloning and streaming.
+- **Recommendation:** Remove the provider and its config plumbing entirely — consistent
+  with the VAD-engine precedent ("only expose what exists", see
+  `050-status-report/GAPS.md`). Reintroduce when a real implementation lands.
+
+### B3: Fix dead `high-quality-resample` feature
+- Declared as empty feature `[]`; `rubato` dependency is unconditional; no consumer or
+  script enables it; CI tests without `--all-features` (ci.yml:178) so the sinc path
+  (`resample.rs:3-36`) is compiled under clippy but never functionally tested.
+- **Fix:** Make `rubato` optional behind the feature; add a CI leg testing with
+  `--features movie-radio-pipeline/high-quality-resample`.
+
+## C. Infrastructure / CI Gaps
+
+| Gap | Evidence | Recommendation |
+|-----|----------|----------------|
+| MSRV enforcement orphaned | `scripts/audit-msrv.sh` defines MSRV=1.88 but is invoked by no workflow; `rust-toolchain.toml` pins only `stable`; no `rust-version` keys | Wire script into `ci.yml`; add `rust-version` to workspace manifest |
+| Benchmark regression tracking unwired | `scripts/check_benchmark_regression.py` + `refresh_benchmark_baseline.sh` exist; `benchmark` job runs only on PR/push (fulfills PHASE-06 §6.7 once scheduled) | Weekly cron job comparing stage timings against stored baseline |
+| Coverage collection missing | Root `.codecov.yml` exists; no workflow uploads coverage | Add cargo-llvm-cov step uploading to Codecov |
+| No release automation | No tag-triggered build/publish/artifact workflow | Backlog: tag-triggered binary artifact workflow |
+| Single-platform CI | Linux x86_64 only | Optional macOS leg if cross-platform support is claimed |
+| Duplicate dep majors | symphonia 0.5+0.6 (rodio), two reqwest versions; `deny.toml:42-45` carries a skip | Track rodio upgrade to drop the symphonia skip |
+
+## D. Test Coverage Gaps
+
+- **movie-radio-types: 0 tests** across ~404 LOC of shared serde/domain types
+  (Segment, Frame, Emotion, AudioOutput round-trips).
+- movie-radio-io / movie-radio-validation parsers: EDL, SRT, VTT each carry exactly
+  one test despite being parse-critical.
+- No crate has an integration `tests/` directory; recommend starting with one
+  end-to-end decode→framing fixture test.
+
+## E. New-Feature Candidates (ranked)
+
+Anchored to the ROADMAP decision at `100-radio-play-95/ROADMAP.md:103`: engine-level
+speech/non-speech discrimination takes priority over profile micro-tuning (modern
+precision plateaued at ~0.7368 vs the 0.95 gate).
+
+1. **Multi-feature VAD tuning** (PHASE-06 §6.8) — feed already-computed spectral
+   features (flux, centroid, band ratios) into classification with profile-aware
+   thresholds. The concrete engine-level path to modern precision recovery; no ML.
+2. **Streaming/chunked processing** (§6.4) — today the pipeline materializes entire
+   soundtracks: 2 h @ 16 kHz mono f32 ≈ 460 MB per copy; `handle_radio_play` decodes
+   the full movie up to three times (`radio_play.rs:90,104,190`);
+   `decode_audio_chunked` accumulates all chunks anyway (`decode.rs:38-44,102`). Frame
+   while decoding instead of handing off `Vec<f32>` boundaries.
+3. **WAV format extension** (§6.5) — direct 24-bit/32-bit-float decode; small win.
+4. **Validation/reporting UX** (§6.6); benchmark baselines covered by C above.
+5. **Silero/WebRTC VAD** (§6.2) — stays deferred per `MILESTONE-C-DECISION.md`;
+   revisit after engine-level DSP improvements plateau.
+
+## Priority Matrix
+
+| ID | Item | Priority | Effort |
+|----|------|----------|--------|
+| A1 | speech_evidence panic fix + regression test | P0 | S |
+| A2 | openai.rs expect removal | P1 | S |
+| A3 | gaps.rs defensive guards | P2 | S |
+| A4 | modal.rs RIFF validation | P2 | S |
+| B1 | voice crate feature-gating (+ Kokoro tokenizer fix) | P2 | M/L |
+| B2 | PocketTts removal | P1 | S/M |
+| B3 | high-quality-resample feature repair | P2 | S |
+| C  | CI wiring (MSRV, benchmark baseline, coverage) | P2 | M |
+| D  | types/io/validation test coverage | P2 | M |
+| E1 | Multi-feature VAD tuning (engine-level lift) | P1 strategic | L |
+
+## Recommended Next Actions
+
+Per the Standard Workflow Loop (AGENTS.md), file issues before editing:
+
+1. 🛠️ Coding Change issue (labels: `coding`, `radio-play`) for **A1** — smallest P0,
+   immediate correctness win; bundle A2–A4 as follow-up scoped PRs.
+2. 🛠️ Coding Change issue for **B2** (PocketTts removal) and **B3**.
+3. ⚡ Performance Change issue (labels: `perf`, `learning`) for **B1** and **C**.
+4. Start a GOAP goal in `plans/GOAP_STATE.md` when execution begins (A1 first).

--- a/plans/FOLLOWUPS.md
+++ b/plans/FOLLOWUPS.md
@@ -4,11 +4,16 @@ Pre-existing issues encountered during implementation runs that could not be fix
 Each entry includes file path, description, priority, and suggested approach.
 
 **Created:** 2026-06-23
-**Updated:** 2026-08-23 — Added dead root `src/` tree finding (PR review sweep)
+**Updated:** 2026-08-25 — Added findings from workspace-wide improvement analysis (`plans/130-improvement-analysis-2026-08-25.md`)
 
 ## Open
 
-None — all triaged followups resolved.
+| File/Path | Description | Priority | Suggested Approach |
+|-----------|-------------|----------|--------------------|
+| `crates/movie-radio-pipeline/src/pipeline/speech_evidence.rs:43-47` | Slice-index panic when a segment timestamp exceeds the decoded frame count: `end_idx` becomes `start_idx + 1 > frames.len()` before slicing | P0 | Clamp like the twin implementation in `pipeline/segmenter/confidence.rs:53-58`: `end_idx.clamp(start_idx + 1, frames.len())`; add an out-of-range-timestamp regression test |
+| `crates/movie-radio-voice/src/voice/openai.rs:91` | Sole library-code `.expect()` in the workspace (`last_err.expect("retry loop runs at least once")`); violates the AGENTS.md no-unwrap rule | P1 | Replace with typed error propagation (the invariant holds, but there must be no panic path) |
+| `crates/movie-radio-voice/src/voice/modal.rs:54-63` | Response parsed as WAV via blind 44-byte header skip; assumes little-endian i16 mono PCM with no container validation | P2 | Validate RIFF/WAVE magic, format tag, and channel count; fall through the provider chain on mismatch |
+| `crates/movie-radio-goap/src/gaps.rs:48,149,165` | `segments.len() - 1` would underflow on an empty slice and `seg.end_ms - seg.start_ms` on an inverted segment (unreachable via current callers; fragile private API) | P2 | Bail on empty slices; saturating subtraction for durations |
 
 ## Resolved
 

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -1,27 +1,26 @@
 # GOAP State
 
-**Current Goal**: Fix FOLLOWUPS correctness bugs — narration zip misalignment (structural Option-alignment), all-failed exit-0 degradation, per-provider text caps
-**Status**: Complete
+**Current Goal**: Fix P0 speech-evidence slice panic for out-of-range segment timestamps (#222)
+**Status**: In Progress
 
 ## Task Graph
-- [x] Task F0: Issue filed; code recon (PipelineContext, assemble pairing, orchestrator loop)
-- [x] Task F1: voice crate — provider cap check in fallback loop before dispatch
-- [x] Task F2: goap lib.rs — `narration_audio: Vec<Option<AudioOutput>>` aligned with scripts
-- [x] Task F3: actions.rs — Some/None pushes, modal cap guard, all-failed bail, assemble skips None
-- [x] Task F4: Tests — fake-provider cap fallback (tokio dev-dep), offline all-failed bail, middle-skip pairing
-- [x] Task F5: PR #214 green CI on 6cb38f7, squash-merged as 5416dd1
-
-## History
-- 2026-08-23: #206 complete (PR #209 → 076601b); audio.cpp spike complete (plans/audiocpp-tts-spike.md).
-- 2026-08-23: Started config-option integration per maintainer directives: config option with OpenAI default; German TTS focus; research-backed.
+- [x] Task G0: Issue #222 filed; code recon (`speech_evidence.rs` vs `segmenter/confidence.rs` clamp pattern)
+- [x] Task G1: Clamp `start_idx`/`end_idx` in `average_frame_stats`, mirroring `segmenter/confidence.rs:53-58`
+- [x] Task G2: Regression test — segment beyond decoded duration does not panic; deterministic output
+- [x] Task G3: Local: `cargo test -p movie-radio-pipeline` 45/45 green; fmt clean; clippy `-p movie-radio-pipeline --all-features -D warnings` clean. Workspace-wide gate blocked locally by pre-existing `llama-cpp-sys` libclang header issue (CI covers it).
+- [ ] Task G4: PR merged (squash), issue #222 closed
 
 ## Evidence Log
-- Issue #206 requirements: reject sample_rate_hz outside 8_000..=48_000; finite speed 0.25..=4.0; text ≤ 10_000 chars; typed errors; validation once in SynthesisOrchestrator::synthesize pre-dispatch.
-- voice/mod.rs:26 defines SynthesisRequest { text, sample_rate_hz: u32, ... } with Default sample_rate_hz=16000.
-- Providers consuming request.sample_rate_hz: kokoro.rs:202, qwen3.rs:142, elevenlabs.rs:70/75, orpheus.rs:201, pockettts.rs:23, modal.rs:67.
-- movie-radio-voice hard-depends on llama-cpp-2 → llama-cpp-sys build needs libclang headers missing locally; CI has them. Local verification limited to syntax-level unless optional feature exists.
+- `speech_evidence.rs:43-47`: `end_idx = min(len).max(start_idx+1)` exceeds len when `start_idx >= len` → `&frames[start..end_idx]` panics (range end out of bounds).
+- Twin correct implementation: `segmenter/confidence.rs:53-58` clamps `start_idx` to `len.saturating_sub(1)` then `end_idx.clamp(start_idx + 1, len)`.
+- Callers: `filter_implausible_speech_segments` wired into extraction pipeline via `pipeline/mod.rs`.
+- Post-fix behavior: out-of-range segments evaluate against the final frame instead of crashing (matches `confidence_for_range` semantics).
+- Analysis source: `plans/130-improvement-analysis-2026-08-25.md` item A1 (P0).
 
 ## History
+- 2026-08-26: Incident recovery — direct-to-main pushes of the Jules #224 branch (stale base, pre-#223) reverted PR #223 content: speech-evidence clamp fix, plans/130 analysis doc, and tracking-doc refreshes. All restored here from 3efca37. Recommendation: enable "require pull request" branch protection to prevent stale-base direct pushes.
+- 2026-08-26: #224 spectral-flux rewrite landed (analysis.rs 505 → 464 LOC) — resolves the LOC violation deferred in FOLLOWUPS.md.
+- 2026-08-25: #222 filed from workspace-wide improvement analysis sweep.
+- 2026-08-23: #206 complete (PR #209 → 076601b); audio.cpp spike complete (plans/audiocpp-tts-spike.md).
 - 2026-08-23: PR sweep complete (#204 merged d64941d, #205 closed, #207 merged e4460af, #208 merged 2d07e78). Issue #206 filed from #205 salvage.
-- 2026-08-23: Started #206 implementation per maintainer go.
-- 2026-08-23 (earlier sweep, archived): #204 merged after bot-push override; #205 closed as AI-slop; #207 fixed Clippy 1.98 breakage; root `src/` dead tree logged in FOLLOWUPS.md.
+- 2026-08-23 (earlier sweep, archived): #204 merged after bot-push override; #207 fixed Clippy 1.98 breakage; root `src/` dead tree logged in FOLLOWUPS.md.


### PR DESCRIPTION
## Incident

Direct-to-main pushes of the Jules #224 branch (`3000bfc..83a1553`, four commits titled `perf(verification): optimize spectral flux loop initialization`) were based on **pre-#223** main and silently reverted merged content:

| Lost content | Impact |
|---|---|
| `speech_evidence.rs` out-of-range clamp fix + regression tests (#222, P0) | Panicking library code returned to main |
| `plans/130-improvement-analysis-2026-08-25.md` | Deleted |
| FOLLOWUPS / GAPS / PHASE-06 / GOAP_STATE refreshes | Reverted to stale state |

This PR restores all of it verbatim from 3efca37. Pipeline tests re-verified: 45/45.

## What is intentionally NOT restored/reverted

- The #224 spectral-flux rewrite itself — it is a legitimate optimization (and resolves the deferred `analysis.rs` 505→464 LOC violation). Only the collateral damage around it is repaired.
- GOAP_STATE history gains an incident entry documenting cause + outcome.

## Recommendation

Enable **require-pull-request** branch protection on `main` so stale-base pushes cannot overwrite merged work. Direct pushes of agent task branches are currently possible and caused this.

## Verification

- `cargo test -p movie-radio-pipeline`: 45/45 pass
- Docs-only otherwise