### PR TITLE
fix(security): harden SynthesisRequest parameter validation against injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - feat(voice): configurable OpenAI-compatible TTS endpoint — `base_url` + optional auth enables local German sidecars (audio.cpp/PocketTTS) with OpenAI as default (#212).
+- fix(voice): harden `SynthesisRequest` validation and percent-encode the ElevenLabs voice endpoint; validate effective voice_id including config fallback (#231).
 - fix(voice): validate `SynthesisRequest` parameters (sample-rate bounds, finite speed, text cap) before TTS dispatch; typed validation errors (#209).
 - perf(verification): pre-allocated magnitude buffers and branchless spectral summation, ~7.5% faster spectral feature extraction (#193).
 - refactor(pipeline): extracted `run_pipeline` processing stages into focused helpers with a shared `timed_stage!` macro (#189).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "movie-radio-types",
  "once_cell",
  "ort",
+ "percent-encoding",
  "qwen_tts",
  "rand 0.10.2",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 async-trait = "0.1"
+percent-encoding = "2"
 reqwest = { version = "0.13", features = ["json", "query"] }
 hound = "3"
 realfft = "3"

--- a/crates/movie-radio-voice/Cargo.toml
+++ b/crates/movie-radio-voice/Cargo.toml
@@ -9,6 +9,7 @@ description = "TTS voice synthesis providers"
 movie-radio-types.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
+percent-encoding.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/movie-radio-voice/src/voice/elevenlabs.rs
+++ b/crates/movie-radio-voice/src/voice/elevenlabs.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use reqwest::Client;
 use std::env;
 use std::io::Cursor;
@@ -10,8 +11,29 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::packet::Packet;
 
-use super::{AudioOutput, ProviderCapabilities, SynthesisRequest, VoiceSynthesizer};
+use super::{
+    is_valid_voice_id, AudioOutput, ProviderCapabilities, SynthesisRequest,
+    SynthesisValidationError, VoiceSynthesizer,
+};
 use crate::config::ElevenLabsConfig;
+
+/// Path-segment encode set: keeps RFC 3986 unreserved characters (`-._~`)
+/// verbatim and percent-encodes everything else, so no character in
+/// `voice_id` can alter URL structure.
+const VOICE_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// Builds the ElevenLabs TTS endpoint with the voice id encoded as a single
+/// URL path segment, so no character in `voice_id` can alter URL structure.
+fn voice_endpoint(voice_id: &str) -> String {
+    format!(
+        "https://api.elevenlabs.io/v1/text-to-speech/{}",
+        utf8_percent_encode(voice_id, VOICE_SEGMENT)
+    )
+}
 
 pub struct ElevenLabsProvider {
     config: ElevenLabsConfig,
@@ -39,7 +61,13 @@ impl VoiceSynthesizer for ElevenLabsProvider {
             .cloned()
             .unwrap_or_else(|| self.config.voice_id.clone());
 
-        let url = format!("https://api.elevenlabs.io/v1/text-to-speech/{}", voice_id);
+        // Validate the *effective* id so the config fallback path is covered
+        // too, not just per-request overrides.
+        if !is_valid_voice_id(&voice_id) {
+            return Err(SynthesisValidationError::InvalidVoiceId.into());
+        }
+
+        let url = voice_endpoint(&voice_id);
 
         let response = self
             .client
@@ -190,4 +218,35 @@ pub fn decode_audio_bytes(bytes: &[u8], target_sample_rate: u32) -> Result<Vec<f
     }
 
     Ok(resampled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::voice_endpoint;
+
+    #[test]
+    fn test_voice_endpoint_leaves_valid_ids_unchanged() {
+        assert_eq!(
+            voice_endpoint("pNInz6obpgDQGcFmaJgB"),
+            "https://api.elevenlabs.io/v1/text-to-speech/pNInz6obpgDQGcFmaJgB"
+        );
+        assert_eq!(
+            voice_endpoint("voice-1.2_abc"),
+            "https://api.elevenlabs.io/v1/text-to-speech/voice-1.2_abc"
+        );
+    }
+
+    #[test]
+    fn test_voice_endpoint_percent_encodes_url_significant_chars() {
+        // Path traversal attempts stay inside one segment.
+        assert_eq!(
+            voice_endpoint("../admin"),
+            "https://api.elevenlabs.io/v1/text-to-speech/..%2Fadmin"
+        );
+        // URL-significant characters are neutralized.
+        assert_eq!(
+            voice_endpoint("a@b:c?x=1#f"),
+            "https://api.elevenlabs.io/v1/text-to-speech/a%40b%3Ac%3Fx%3D1%23f"
+        );
+    }
 }

--- a/crates/movie-radio-voice/src/voice/mod.rs
+++ b/crates/movie-radio-voice/src/voice/mod.rs
@@ -5,6 +5,10 @@ use std::ops::RangeInclusive;
 
 /// Maximum accepted text length per synthesis request, in characters.
 pub const MAX_REQUEST_TEXT_CHARS: usize = 10_000;
+/// Maximum accepted voice ID length, in characters.
+pub const MAX_VOICE_ID_CHARS: usize = 128;
+/// Maximum accepted language tag length, in characters.
+pub const MAX_LANGUAGE_CHARS: usize = 32;
 /// Inclusive bounds for `sample_rate_hz`, in Hz.
 pub const SAMPLE_RATE_RANGE_HZ: RangeInclusive<u32> = 8_000..=48_000;
 /// Inclusive bounds for `speed`.
@@ -50,14 +54,48 @@ pub enum SynthesisValidationError {
     SpeedOutOfRange(f32),
     #[error("text length {0} chars exceeds maximum of {MAX_REQUEST_TEXT_CHARS}")]
     TextTooLong(usize),
+    #[error("voice_id is empty, contains invalid characters, or exceeds maximum length of {MAX_VOICE_ID_CHARS}")]
+    InvalidVoiceId,
+    #[error("language tag contains invalid characters or exceeds maximum length of {MAX_LANGUAGE_CHARS}")]
+    InvalidLanguage,
+}
+
+fn is_valid_voice_id_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.')
+}
+
+/// Conservative charset/length check for provider voice identifiers.
+///
+/// This is *not* a per-provider format validation; it rejects inputs that are
+/// dangerous when interpolated into URLs or identifiers. Providers must still
+/// percent-encode path segments (see `elevenlabs::voice_endpoint`).
+pub(crate) fn is_valid_voice_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.chars().count() <= MAX_VOICE_ID_CHARS
+        && id.chars().all(is_valid_voice_id_char)
+}
+
+fn is_valid_language_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_')
+}
+
+fn is_valid_language(lang: &str) -> bool {
+    !lang.is_empty()
+        && lang.chars().count() <= MAX_LANGUAGE_CHARS
+        && lang.chars().all(is_valid_language_char)
 }
 
 impl SynthesisRequest {
     /// Validates provider-facing parameters before any TTS dispatch.
     ///
     /// Rejects sample rates outside [`SAMPLE_RATE_RANGE_HZ`], non-finite or
-    /// out-of-range speeds ([`SPEED_RANGE`]), and texts longer than
-    /// [`MAX_REQUEST_TEXT_CHARS`] characters.
+    /// out-of-range speeds ([`SPEED_RANGE`]), texts longer than
+    /// [`MAX_REQUEST_TEXT_CHARS`] characters, invalid `voice_id` inputs,
+    /// and invalid `language` inputs.
+    ///
+    /// Note: `language` is a conservative charset check, not a BCP-47 tag
+    /// validation; providers resolve unknown tags against their own
+    /// capabilities.
     pub fn validate(&self) -> Result<(), SynthesisValidationError> {
         if !SAMPLE_RATE_RANGE_HZ.contains(&self.sample_rate_hz) {
             return Err(SynthesisValidationError::SampleRateOutOfRange(
@@ -70,6 +108,14 @@ impl SynthesisRequest {
         let len = self.text.chars().count();
         if len > MAX_REQUEST_TEXT_CHARS {
             return Err(SynthesisValidationError::TextTooLong(len));
+        }
+        if let Some(ref voice_id) = self.voice_id {
+            if !is_valid_voice_id(voice_id) {
+                return Err(SynthesisValidationError::InvalidVoiceId);
+            }
+        }
+        if !is_valid_language(&self.language) {
+            return Err(SynthesisValidationError::InvalidLanguage);
         }
         Ok(())
     }
@@ -299,6 +345,53 @@ mod tests {
             request(&over, 1.0, 192_000).validate(),
             Err(SynthesisValidationError::SampleRateOutOfRange(192_000))
         ));
+    }
+
+    #[test]
+    fn test_voice_id_validation() {
+        let mut req = SynthesisRequest::default();
+
+        for valid_id in ["pNInz6obpgDQGcFmaJgB", "onyx", "voice-123_abc.v1"] {
+            req.voice_id = Some(valid_id.to_string());
+            assert_eq!(req.validate(), Ok(()));
+        }
+
+        let long_id = "a".repeat(MAX_VOICE_ID_CHARS + 1);
+        for invalid_id in [
+            "",
+            &long_id,
+            "../admin",
+            "voice/id",
+            "voice\nid",
+            "voice?param=1",
+            "voice@host",
+            "voice:scheme",
+        ] {
+            req.voice_id = Some(invalid_id.to_string());
+            assert_eq!(
+                req.validate(),
+                Err(SynthesisValidationError::InvalidVoiceId)
+            );
+        }
+    }
+
+    #[test]
+    fn test_language_validation() {
+        let mut req = SynthesisRequest::default();
+
+        for valid_lang in ["de", "en", "en-US", "zh_CN"] {
+            req.language = valid_lang.to_string();
+            assert_eq!(req.validate(), Ok(()));
+        }
+
+        let long_lang = "a".repeat(MAX_LANGUAGE_CHARS + 1);
+        for invalid_lang in ["", &long_lang, "de;cat /etc/passwd", "de\r\n", "en.US"] {
+            req.language = invalid_lang.to_string();
+            assert_eq!(
+                req.validate(),
+                Err(SynthesisValidationError::InvalidLanguage)
+            );
+        }
     }
 
     struct FakeProvider {


### PR DESCRIPTION
Hardens parameter validation for `SynthesisRequest` in `crates/movie-radio-voice` by validating `voice_id` (rejecting empty values, path traversal `..`, lengths over 128 chars, and invalid characters) and `language` tags (rejecting empty values, lengths over 32 chars, and invalid characters).

---
*PR created automatically by Jules for task [9789213273546788104](https://jules.google.com/task/9789213273546788104) started by @d-oit*