### PR TITLE
fix(security): validate effective voice ID in OpenAI TTS provider

### DIFF
--- a/crates/movie-radio-voice/src/voice/openai.rs
+++ b/crates/movie-radio-voice/src/voice/openai.rs
@@ -4,7 +4,10 @@ use reqwest::Client;
 use std::env;
 use std::time::Duration;
 
-use super::{AudioOutput, ProviderCapabilities, SynthesisRequest, VoiceSynthesizer};
+use super::{
+    is_valid_voice_id, AudioOutput, ProviderCapabilities, SynthesisRequest,
+    SynthesisValidationError, VoiceSynthesizer,
+};
 use crate::config::OpenAiConfig;
 
 /// Attempts per synthesis for transient transport failures (connect/timeout).
@@ -48,6 +51,10 @@ impl OpenAiTtsProvider {
         } else {
             self.config.voice.clone()
         };
+
+        if !is_valid_voice_id(&voice) {
+            return Err(SynthesisValidationError::InvalidVoiceId.into());
+        }
 
         let mut req = self.client.post(self.endpoint()).json(&serde_json::json!({
             "model": self.config.model,
@@ -194,6 +201,58 @@ mod tests {
             voice: "onyx".to_string(),
             response_format: "mp3".to_string(),
         }
+    }
+
+    #[test]
+    fn test_build_request_rejects_invalid_voice_id() {
+        let invalid_cfg = OpenAiConfig {
+            api_key_env: None,
+            base_url: "https://api.openai.com/v1".to_string(),
+            model: "tts-1".to_string(),
+            voice: "../invalid_voice".to_string(),
+            response_format: "mp3".to_string(),
+        };
+        let provider = OpenAiTtsProvider::new(invalid_cfg);
+        let req = SynthesisRequest::default();
+        let res = provider.build_request(&req);
+        assert!(res.is_err());
+        assert_eq!(
+            res.err()
+                .unwrap()
+                .downcast::<SynthesisValidationError>()
+                .unwrap(),
+            SynthesisValidationError::InvalidVoiceId
+        );
+
+        let valid_cfg = config(None, None);
+        let provider = OpenAiTtsProvider::new(valid_cfg);
+        let req_override = SynthesisRequest {
+            voice_id: Some("voice/path/traversal".to_string()),
+            ..SynthesisRequest::default()
+        };
+        let res_override = provider.build_request(&req_override);
+        assert!(res_override.is_err());
+        assert_eq!(
+            res_override
+                .err()
+                .unwrap()
+                .downcast::<SynthesisValidationError>()
+                .unwrap(),
+            SynthesisValidationError::InvalidVoiceId
+        );
+    }
+
+    #[test]
+    fn test_build_request_accepts_valid_voice_id() {
+        let provider = OpenAiTtsProvider::new(config(None, None));
+        let req = SynthesisRequest::default();
+        assert!(provider.build_request(&req).is_ok());
+
+        let req_override = SynthesisRequest {
+            voice_id: Some("alloy".to_string()),
+            ..SynthesisRequest::default()
+        };
+        assert!(provider.build_request(&req_override).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Add effective voice ID input validation in `OpenAiTtsProvider::build_request` to ensure that both request overrides and configuration fallback voice parameters are validated with `is_valid_voice_id` before constructing API requests, preventing path traversal or invalid character injection in voice parameters.

---
*PR created automatically by Jules for task [11591308243325855645](https://jules.google.com/task/11591308243325855645) started by @d-oit*

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a security-focused change concentrated in the OpenAI TTS provider, with validation and provider behavior covered alongside its tests. Its reach extends through the voice subsystem into dependent code paths, warranting close review despite the single-file scope.*

**🔴 CRITICAL blast radius. A security-focused OpenAI TTS provider change in `crates/movie-radio-voice/src/voice/openai.rs` reaches 4 dependents across 5 affected flows.**

The change centers on `OpenAiTtsProvider` and `build_request`, with related connection, endpoint, authentication, sidecar, and default-configuration tests in the same provider file. Review the effective voice ID validation within request construction first, then verify its interaction with `sidecar_provider` and the existing provider defaults.

Impact is concentrated in the human-named `Voice` module, with a smaller connection to `Database`. The file itself is rated LOW risk and there are no HIGH or CRITICAL risk files, but the CRITICAL blast level indicates that callers and downstream execution paths through this provider deserve careful regression review.

_Added by GitNexus for PR #252. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->