### PR TITLE
feat(pipeline): WebRTC VAD behind feature flag, sample-level engine routing (#253)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,6 +2369,7 @@ dependencies = [
  "tera",
  "tokio",
  "tracing",
+ "webrtc-vad",
 ]
 
 [[package]]
@@ -5068,6 +5069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc-vad"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a1e40fd6ca90be95459152a2537f2ba4286ee1b13073f7ebcaa74fc94e3008"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.8"
 dotenvy = "0.15"
 tera = "1.19"
 url = "2"
+webrtc-vad = "0.4"
 libsql = { version = "0.9", default-features = false, features = ["core"] }
 symphonia = { version = "0.6", features = ["mp3", "wav", "flac", "ogg", "pcm"] }
 rodio = { version = "0.22", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Configuration profiles are stored in `config/profiles/` (e.g., `modern-optimized
 - `vad_threshold_delta`: Delta added to baseline energy threshold (default: 0.0).
 - `prompt_min_duration_ms`: Minimum segment duration for prompt generation in milliseconds (default: 2500).
 - `prompt_min_confidence`: Minimum confidence threshold for prompt generation (default: 0.65).
-- `vad_engine`: Classification engine ("energy", "spectral", or "hybrid", default: "energy").
+- `vad_engine`: Classification engine ("energy", "spectral", "hybrid", "webrtc", or "silero", default: "energy"). `webrtc` needs `timeline --features webrtc-vad`; `silero` is reserved and reports its status via ADR-127.
 
 ### Narrator Voice Configuration (audio.cpp & GPU Cloud)
 

--- a/crates/movie-radio-pipeline/Cargo.toml
+++ b/crates/movie-radio-pipeline/Cargo.toml
@@ -25,10 +25,12 @@ tera.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
+webrtc-vad = { workspace = true, optional = true }
 
 [features]
 default = []
 high-quality-resample = []
+webrtc-vad = ["dep:webrtc-vad"]
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/movie-radio-pipeline/src/pipeline/mod.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/mod.rs
@@ -138,7 +138,7 @@ fn extract_timeline_chunked(
         let mut combined_samples = prev_samples.clone();
         combined_samples.extend_from_slice(chunk_samples);
         let vad_output = classify_with_engine(
-            &mut vad_engine,
+            vad_engine.as_mut(),
             &combined_frames,
             &combined_samples,
             cfg.sample_rate_hz,
@@ -224,7 +224,7 @@ fn extract_timeline_chunked(
         } else {
             prev_frames = frames;
             prev_likelihoods = chunk_likelihoods.to_vec();
-            prev_samples = chunk_samples.clone();
+            prev_samples.clone_from(chunk_samples);
         }
 
         chunk_offset_ms += chunk_ms;
@@ -353,7 +353,7 @@ fn vad_stage(mono: &[f32], frames: &[Frame], cfg: &AnalysisConfig, eff_thresh: f
     let mut engine: Box<dyn VadEngine> = create_engine(&cfg.vad_engine, thresh, flat, ent, cent_min, cent_max, cfg.sample_rate_hz, cfg.frame_ms)?;
     let name = engine.name();
     let output = timed_stage!(stage_ms, vad_ms, {
-        classify_with_engine(&mut engine, frames, mono, cfg.sample_rate_hz, cfg.frame_ms)?
+        classify_with_engine(engine.as_mut(), frames, mono, cfg.sample_rate_hz, cfg.frame_ms)?
     });
     info!(stage = "vad", ms = stage_ms.vad_ms, engine = name, "stage complete");
     Ok((output.decisions, output.likelihoods))

--- a/crates/movie-radio-pipeline/src/pipeline/mod.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/mod.rs
@@ -219,8 +219,16 @@ fn extract_timeline_chunked(
             prev_frames = frames[frames.len() - warmup_frames..].to_vec();
             prev_likelihoods =
                 chunk_likelihoods[chunk_likelihoods.len() - warmup_frames..].to_vec();
-            let warmup_samples = warmup_frames * frame_len(cfg.sample_rate_hz, frame_ms);
-            prev_samples = tail_samples(chunk_samples, warmup_samples);
+            // Exact sample coverage of the retained frames: full frames except
+            // possibly the chunk tail, so sample-based engines stay aligned
+            // with frame-based decisions.
+            let flen = frame_len(cfg.sample_rate_hz, frame_ms);
+            let tail = chunk_samples.len() % flen;
+            let mut sample_count = warmup_frames * flen;
+            if tail != 0 {
+                sample_count -= flen - tail;
+            }
+            prev_samples = tail_samples(chunk_samples, sample_count);
         } else {
             prev_frames = frames;
             prev_likelihoods = chunk_likelihoods.to_vec();

--- a/crates/movie-radio-pipeline/src/pipeline/mod.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/mod.rs
@@ -20,7 +20,9 @@ use std::{path::Path, time::Instant};
 use anyhow::Result;
 use tracing::info;
 
-use crate::pipeline::vad::{adapt_spectral_thresholds, create_engine, VadEngine};
+use crate::pipeline::vad::{
+    adapt_spectral_thresholds, classify_with_engine, create_engine, VadEngine,
+};
 use filters::{
     ambiguous_expand_max_ms, residual_bridge_gap_ms, should_apply_speech_evidence_filter,
     should_apply_verification_filter,
@@ -109,6 +111,7 @@ fn extract_timeline_chunked(
     let mut chunk_offset_ms: u64 = 0;
     let mut prev_frames: Vec<movie_radio_types::Frame> = Vec::new();
     let mut prev_likelihoods: Vec<f32> = Vec::new();
+    let mut prev_samples: Vec<f32> = Vec::new();
 
     for (chunk_idx, chunk_samples) in chunks.iter().enumerate() {
         let chunk_len = chunk_samples.len();
@@ -121,16 +124,26 @@ fn extract_timeline_chunked(
 
         let mut combined_likelihoods = prev_likelihoods.clone();
 
-        let vad_engine = create_engine(
+        let mut vad_engine = create_engine(
             &cfg.vad_engine,
             vad_threshold,
             vad_flatness_max,
             vad_entropy_min,
             vad_centroid_min,
             vad_centroid_max,
+            cfg.sample_rate_hz,
+            frame_ms,
         )?;
 
-        let vad_output = vad_engine.classify(&combined_frames);
+        let mut combined_samples = prev_samples.clone();
+        combined_samples.extend_from_slice(chunk_samples);
+        let vad_output = classify_with_engine(
+            &mut vad_engine,
+            &combined_frames,
+            &combined_samples,
+            cfg.sample_rate_hz,
+            frame_ms,
+        )?;
         let speech = vad_output.decisions;
         combined_likelihoods.extend_from_slice(&vad_output.likelihoods);
 
@@ -206,9 +219,12 @@ fn extract_timeline_chunked(
             prev_frames = frames[frames.len() - warmup_frames..].to_vec();
             prev_likelihoods =
                 chunk_likelihoods[chunk_likelihoods.len() - warmup_frames..].to_vec();
+            let warmup_samples = warmup_frames * frame_len(cfg.sample_rate_hz, frame_ms);
+            prev_samples = tail_samples(chunk_samples, warmup_samples);
         } else {
             prev_frames = frames;
             prev_likelihoods = chunk_likelihoods.to_vec();
+            prev_samples = chunk_samples.clone();
         }
 
         chunk_offset_ms += chunk_ms;
@@ -256,7 +272,8 @@ fn run_pipeline(input: &Path, cfg: &AnalysisConfig) -> Result<PipelineArtifacts>
     let frames = framing_stage(&mono, cfg, &mut stage_ms);
     let frame_count = frames.len();
 
-    let (speech, frame_likelihoods) = vad_stage(&frames, cfg, effective_threshold, &mut stage_ms)?;
+    let (speech, frame_likelihoods) =
+        vad_stage(&mono, &frames, cfg, effective_threshold, &mut stage_ms)?;
     let smoothed = smoothing_stage(&speech, &frames, &frame_likelihoods, cfg, &mut stage_ms);
     let speech_segments = speech_segments_stage(&smoothed, &frame_likelihoods, cfg, &mut stage_ms);
     let filtered_speech = merging_stage(&speech_segments, &frames, cfg, &mut stage_ms);
@@ -309,8 +326,20 @@ fn framing_stage(mono: &[f32], cfg: &AnalysisConfig, stage_ms: &mut StageDuratio
     frames
 }
 
+fn frame_len(sample_rate_hz: u32, frame_ms: u32) -> usize {
+    ((sample_rate_hz as usize * frame_ms as usize) / 1000).max(1)
+}
+
+fn tail_samples(samples: &[f32], n: usize) -> Vec<f32> {
+    if n >= samples.len() {
+        samples.to_vec()
+    } else {
+        samples[samples.len() - n..].to_vec()
+    }
+}
+
 #[rustfmt::skip]
-fn vad_stage(frames: &[Frame], cfg: &AnalysisConfig, eff_thresh: f32, stage_ms: &mut StageDurations) -> Result<(Vec<bool>, Vec<f32>)> {
+fn vad_stage(mono: &[f32], frames: &[Frame], cfg: &AnalysisConfig, eff_thresh: f32, stage_ms: &mut StageDurations) -> Result<(Vec<bool>, Vec<f32>)> {
     let (thresh, flat, ent, cent_min, cent_max) = if cfg.vad_engine == "spectral" {
         let ad = adapt_spectral_thresholds(
             frames, eff_thresh, cfg.spectral_flatness_max,
@@ -321,10 +350,10 @@ fn vad_stage(frames: &[Frame], cfg: &AnalysisConfig, eff_thresh: f32, stage_ms: 
     } else {
         (eff_thresh, cfg.spectral_flatness_max, cfg.spectral_entropy_min, cfg.spectral_centroid_min, cfg.spectral_centroid_max)
     };
-    let engine: Box<dyn VadEngine> = create_engine(&cfg.vad_engine, thresh, flat, ent, cent_min, cent_max)?;
+    let mut engine: Box<dyn VadEngine> = create_engine(&cfg.vad_engine, thresh, flat, ent, cent_min, cent_max, cfg.sample_rate_hz, cfg.frame_ms)?;
     let name = engine.name();
     let output = timed_stage!(stage_ms, vad_ms, {
-        engine.classify(frames)
+        classify_with_engine(&mut engine, frames, mono, cfg.sample_rate_hz, cfg.frame_ms)?
     });
     info!(stage = "vad", ms = stage_ms.vad_ms, engine = name, "stage complete");
     Ok((output.decisions, output.likelihoods))

--- a/crates/movie-radio-pipeline/src/pipeline/vad/engine.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/vad/engine.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use movie_radio_types::frame::Frame;
 
 pub struct VadResult {
@@ -17,4 +18,20 @@ impl VadResult {
 pub trait VadEngine: Send + Sync {
     fn classify(&self, frames: &[Frame]) -> VadResult;
     fn name(&self) -> &'static str;
+
+    /// Whether this engine consumes raw samples instead of pre-computed frames.
+    fn uses_raw_samples(&self) -> bool {
+        false
+    }
+
+    /// Classify raw mono samples at the pipeline sample rate. Only called when
+    /// [`VadEngine::uses_raw_samples`] is true; the default rejects.
+    fn classify_samples(
+        &mut self,
+        _samples: &[f32],
+        _sample_rate_hz: u32,
+        _frame_ms: u32,
+    ) -> Result<VadResult> {
+        anyhow::bail!("engine '{}' requires pre-computed frames", self.name());
+    }
 }

--- a/crates/movie-radio-pipeline/src/pipeline/vad/mod.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/vad/mod.rs
@@ -2,6 +2,8 @@ mod energy;
 mod engine;
 mod hybrid;
 mod spectral;
+#[cfg(feature = "webrtc-vad")]
+mod webrtc;
 
 use anyhow::{bail, Result};
 
@@ -11,6 +13,8 @@ pub use energy::EnergyVad;
 pub use engine::VadEngine;
 pub use hybrid::HybridVad;
 pub use spectral::SpectralVad;
+#[cfg(feature = "webrtc-vad")]
+pub use webrtc::WebRtcVad;
 
 const MIN_ADAPTIVE_THRESHOLD: f32 = 0.0001;
 const MAX_ADAPTIVE_THRESHOLD: f32 = 0.05;
@@ -31,6 +35,8 @@ pub fn create_engine(
     entropy_min: Option<f32>,
     centroid_min: Option<f32>,
     centroid_max: Option<f32>,
+    _sample_rate_hz: u32,
+    _frame_ms: u32,
 ) -> Result<Box<dyn VadEngine>> {
     match name {
         "energy" => Ok(Box::new(EnergyVad::new(threshold))),
@@ -52,7 +58,43 @@ pub fn create_engine(
             };
             Ok(Box::new(engine))
         }
+        "webrtc" => {
+            #[cfg(feature = "webrtc-vad")]
+            {
+                Ok(Box::new(webrtc::WebRtcVad::new(
+                    threshold,
+                    _sample_rate_hz,
+                    _frame_ms,
+                )?))
+            }
+            #[cfg(not(feature = "webrtc-vad"))]
+            {
+                bail!("VAD engine 'webrtc' needs `--features webrtc-vad` (rebuild with the feature enabled)");
+            }
+        }
+        // Silero is accepted as a name but deferred: silero-vad-rust 6.2.2
+        // targets a pre-rc.13 ort API while the workspace unified on rc.13,
+        // and there is no weight-vendoring convention yet (see ADR-127).
+        "silero" => {
+            bail!("VAD engine 'silero' is not yet implemented (blocked on ort unification, see ADR-127)");
+        }
         _ => bail!("unknown VAD engine '{name}'"),
+    }
+}
+
+/// Classify with automatic routing: sample-based engines run on raw samples,
+/// frame-based engines on pre-computed frames.
+pub fn classify_with_engine(
+    engine: &mut Box<dyn VadEngine>,
+    frames: &[Frame],
+    samples: &[f32],
+    sample_rate_hz: u32,
+    frame_ms: u32,
+) -> Result<engine::VadResult> {
+    if engine.uses_raw_samples() {
+        engine.classify_samples(samples, sample_rate_hz, frame_ms)
+    } else {
+        Ok(engine.classify(frames))
     }
 }
 
@@ -153,7 +195,39 @@ mod tests {
 
     #[test]
     fn create_engine_supports_hybrid() {
-        let engine = create_engine("hybrid", 0.015, None, None, None, None).unwrap();
+        let engine = create_engine("hybrid", 0.015, None, None, None, None, 16000, 20).unwrap();
         assert_eq!(engine.name(), "hybrid");
+    }
+
+    #[test]
+    fn unknown_engine_is_rejected() {
+        assert!(create_engine("bogus", 0.015, None, None, None, None, 16000, 20).is_err());
+    }
+
+    fn engine_error(name: &str, threshold: f32) -> String {
+        match create_engine(name, threshold, None, None, None, None, 16000, 20) {
+            Ok(_) => String::from("expected error, got engine"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    #[cfg(not(feature = "webrtc-vad"))]
+    fn webrtc_without_feature_errors_helpfully() {
+        let err = engine_error("webrtc", 0.015);
+        assert!(err.contains("--features webrtc-vad"), "got: {err}");
+    }
+
+    #[test]
+    fn silero_reports_deferred_status() {
+        let err = engine_error("silero", 0.5);
+        assert!(err.contains("not yet implemented"), "got: {err}");
+    }
+
+    #[test]
+    fn frame_engines_reject_sample_classification() {
+        let mut engine = create_engine("energy", 0.015, None, None, None, None, 16000, 20).unwrap();
+        assert!(!engine.uses_raw_samples());
+        assert!(engine.classify_samples(&[0.0; 320], 16000, 20).is_err());
     }
 }

--- a/crates/movie-radio-pipeline/src/pipeline/vad/mod.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/vad/mod.rs
@@ -85,7 +85,7 @@ pub fn create_engine(
 /// Classify with automatic routing: sample-based engines run on raw samples,
 /// frame-based engines on pre-computed frames.
 pub fn classify_with_engine(
-    engine: &mut Box<dyn VadEngine>,
+    engine: &mut dyn VadEngine,
     frames: &[Frame],
     samples: &[f32],
     sample_rate_hz: u32,

--- a/crates/movie-radio-pipeline/src/pipeline/vad/webrtc.rs
+++ b/crates/movie-radio-pipeline/src/pipeline/vad/webrtc.rs
@@ -1,0 +1,155 @@
+use super::engine::{VadEngine, VadResult};
+use anyhow::{bail, Result};
+
+/// WebRTC VAD engine (feature `webrtc-vad`).
+///
+/// Native fit for the default pipeline (16 kHz, 20 ms frames). f32 samples are
+/// converted to clamped i16; trailing partial frames are zero-padded so the
+/// decision count always matches `framing::build_frames` output.
+/// `webrtc_vad::Vad` is `!Send` (raw FFI pointer) and `unsafe` is forbidden
+/// in this workspace, so only plain config is stored and a fresh instance is
+/// built per classification call. Stateless across calls keeps output
+/// deterministic for identical input.
+pub struct WebRtcVad {
+    threshold: f32,
+    sample_rate_hz: u32,
+    frame_ms: u32,
+}
+
+/// Map pipeline sensitivity to a WebRTC aggressiveness mode.
+/// Higher pipeline threshold = less sensitive = more aggressive VAD.
+fn mode_for_threshold(threshold: f32) -> webrtc_vad::VadMode {
+    use webrtc_vad::VadMode;
+    if threshold < 0.01 {
+        VadMode::Quality
+    } else if threshold < 0.05 {
+        VadMode::LowBitrate
+    } else if threshold < 0.2 {
+        VadMode::Aggressive
+    } else {
+        VadMode::VeryAggressive
+    }
+}
+
+fn rate_for_hz(sample_rate_hz: u32) -> Result<webrtc_vad::SampleRate> {
+    use webrtc_vad::SampleRate;
+    match sample_rate_hz {
+        8000 => Ok(SampleRate::Rate8kHz),
+        16000 => Ok(SampleRate::Rate16kHz),
+        32000 => Ok(SampleRate::Rate32kHz),
+        48000 => Ok(SampleRate::Rate48kHz),
+        other => bail!("webrtc VAD supports 8000/16000/32000/48000 Hz, got {other}"),
+    }
+}
+
+impl WebRtcVad {
+    pub fn new(threshold: f32, sample_rate_hz: u32, frame_ms: u32) -> Result<Self> {
+        rate_for_hz(sample_rate_hz)?;
+        if !matches!(frame_ms, 10 | 20 | 30) {
+            bail!("webrtc VAD supports 10/20/30 ms frames, got {frame_ms}");
+        }
+        Ok(Self {
+            threshold,
+            sample_rate_hz,
+            frame_ms,
+        })
+    }
+
+    fn frame_len(&self) -> usize {
+        (self.sample_rate_hz as usize * self.frame_ms as usize) / 1000
+    }
+}
+
+impl VadEngine for WebRtcVad {
+    fn classify(&self, _frames: &[movie_radio_types::Frame]) -> VadResult {
+        // Unreachable through the pipeline router (`uses_raw_samples` is true);
+        // return empty rather than panic for direct misuse.
+        VadResult::new(Vec::new(), Vec::new())
+    }
+
+    fn name(&self) -> &'static str {
+        "webrtc"
+    }
+
+    fn uses_raw_samples(&self) -> bool {
+        true
+    }
+
+    fn classify_samples(
+        &mut self,
+        samples: &[f32],
+        sample_rate_hz: u32,
+        frame_ms: u32,
+    ) -> Result<VadResult> {
+        if sample_rate_hz != self.sample_rate_hz || frame_ms != self.frame_ms {
+            bail!(
+                "webrtc VAD configured for {}/{} ms, got {}/{} ms",
+                self.sample_rate_hz,
+                self.frame_ms,
+                sample_rate_hz,
+                frame_ms
+            );
+        }
+        let frame_len = self.frame_len();
+        let rate = rate_for_hz(self.sample_rate_hz)?;
+        let mut vad =
+            webrtc_vad::Vad::new_with_rate_and_mode(rate, mode_for_threshold(self.threshold));
+        let mut decisions = Vec::new();
+        let mut likelihoods = Vec::new();
+        let mut int_buf = vec![0i16; frame_len];
+        for chunk in samples.chunks(frame_len) {
+            if chunk.is_empty() {
+                continue;
+            }
+            for (dst, &s) in int_buf.iter_mut().zip(chunk.iter()) {
+                *dst = (s.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i16;
+            }
+            for dst in int_buf.iter_mut().skip(chunk.len()) {
+                *dst = 0;
+            }
+            let speech = vad
+                .is_voice_segment(&int_buf)
+                .map_err(|()| anyhow::anyhow!("webrtc VAD rejected frame length"))?;
+            decisions.push(speech);
+            likelihoods.push(if speech { 1.0 } else { 0.0 });
+        }
+        Ok(VadResult::new(decisions, likelihoods))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_unsupported_rate() {
+        assert!(WebRtcVad::new(0.015, 44100, 20).is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_frame_ms() {
+        assert!(WebRtcVad::new(0.015, 16000, 25).is_err());
+    }
+
+    #[test]
+    fn silence_is_deterministic_non_speech() -> Result<()> {
+        let mut vad = WebRtcVad::new(0.015, 16000, 20)?;
+        let silence = vec![0.0f32; 3200];
+        let first = vad.classify_samples(&silence, 16000, 20)?;
+        let second = vad.classify_samples(&silence, 16000, 20)?;
+        assert_eq!(first.decisions.len(), 10);
+        assert_eq!(first.decisions, second.decisions);
+        assert!(first.decisions.iter().all(|&d| !d));
+        Ok(())
+    }
+
+    #[test]
+    fn decision_count_matches_framing_with_tail() -> Result<()> {
+        let mut vad = WebRtcVad::new(0.015, 16000, 20)?;
+        // 330 samples -> framing yields 2 frames (320 + 10 tail).
+        let out = vad.classify_samples(&vec![0.0f32; 330], 16000, 20)?;
+        assert_eq!(out.decisions.len(), 2);
+        assert_eq!(out.likelihoods.len(), 2);
+        Ok(())
+    }
+}

--- a/crates/movie-radio-timeline/Cargo.toml
+++ b/crates/movie-radio-timeline/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [features]
 playback = ["movie-radio-io/playback"]
+webrtc-vad = ["movie-radio-pipeline/webrtc-vad"]
 
 [dependencies]
 movie-radio-types.workspace = true

--- a/crates/movie-radio-timeline/src/cli.rs
+++ b/crates/movie-radio-timeline/src/cli.rs
@@ -25,7 +25,7 @@ pub enum Commands {
         min_silence_ms: Option<u32>,
         #[arg(long)]
         max_non_voice_ms: Option<u32>,
-        #[arg(long, default_value = "energy", value_parser = ["energy", "spectral", "hybrid"])]
+        #[arg(long, default_value = "energy", value_parser = ["energy", "spectral", "hybrid", "webrtc", "silero"])]
         vad_engine: String,
         #[arg(long)]
         calibration_profile: Option<PathBuf>,
@@ -92,7 +92,7 @@ pub enum Commands {
         min_silence_ms: Option<u32>,
         #[arg(long)]
         max_non_voice_ms: Option<u32>,
-        #[arg(long, default_value = "energy", value_parser = ["energy", "spectral", "hybrid"])]
+        #[arg(long, default_value = "energy", value_parser = ["energy", "spectral", "hybrid", "webrtc", "silero"])]
         vad_engine: String,
         #[arg(long)]
         calibration_profile: Option<PathBuf>,
@@ -118,7 +118,7 @@ pub enum Commands {
         min_silence_ms: Option<u32>,
         #[arg(long)]
         max_non_voice_ms: Option<u32>,
-        #[arg(long, default_value = "energy", value_parser = ["energy", "spectral", "hybrid"])]
+        #[arg(long, default_value = "energy", value_parser = ["energy", "spectral", "hybrid", "webrtc", "silero"])]
         vad_engine: String,
         #[arg(long)]
         calibration_profile: Option<PathBuf>,

--- a/crates/movie-radio-timeline/src/config.rs
+++ b/crates/movie-radio-timeline/src/config.rs
@@ -50,9 +50,16 @@ pub fn build_analysis_config(
     Ok(cfg)
 }
 
+const ENV_SAMPLE_RATE: &str = "TIMELINE_SAMPLE_RATE";
+const ENV_FRAME_MS: &str = "TIMELINE_FRAME_MS";
+const ENV_MIN_SPEECH_MS: &str = "TIMELINE_MIN_SPEECH_MS";
+const ENV_MIN_SILENCE_MS: &str = "TIMELINE_MIN_SILENCE_MS";
+const ENV_ENERGY_THRESHOLD: &str = "TIMELINE_ENERGY_THRESHOLD";
+const ENV_PARALLEL_FEATURES: &str = "TIMELINE_PARALLEL_FEATURES";
+
 fn apply_env_overrides(mut cfg: AnalysisConfig) -> Result<AnalysisConfig> {
-    if let Ok(v) = env::var("TIMELINE_SAMPLE_RATE") {
-        cfg.sample_rate_hz = parse_env_value("TIMELINE_SAMPLE_RATE", &v)?;
+    if let Ok(v) = env::var(ENV_SAMPLE_RATE) {
+        cfg.sample_rate_hz = parse_env_value(ENV_SAMPLE_RATE, &v)?;
         if !(8_000..=48_000).contains(&cfg.sample_rate_hz) {
             bail!(
                 "invalid TIMELINE_SAMPLE_RATE={}: must be within 8_000..=48_000 Hz",
@@ -60,20 +67,20 @@ fn apply_env_overrides(mut cfg: AnalysisConfig) -> Result<AnalysisConfig> {
             );
         }
     }
-    if let Ok(v) = env::var("TIMELINE_FRAME_MS") {
-        cfg.frame_ms = parse_env_value("TIMELINE_FRAME_MS", &v)?;
+    if let Ok(v) = env::var(ENV_FRAME_MS) {
+        cfg.frame_ms = parse_env_value(ENV_FRAME_MS, &v)?;
     }
-    if let Ok(v) = env::var("TIMELINE_MIN_SPEECH_MS") {
-        cfg.min_speech_ms = parse_env_value("TIMELINE_MIN_SPEECH_MS", &v)?;
+    if let Ok(v) = env::var(ENV_MIN_SPEECH_MS) {
+        cfg.min_speech_ms = parse_env_value(ENV_MIN_SPEECH_MS, &v)?;
     }
-    if let Ok(v) = env::var("TIMELINE_MIN_SILENCE_MS") {
-        cfg.min_non_voice_ms = parse_env_value("TIMELINE_MIN_SILENCE_MS", &v)?;
+    if let Ok(v) = env::var(ENV_MIN_SILENCE_MS) {
+        cfg.min_non_voice_ms = parse_env_value(ENV_MIN_SILENCE_MS, &v)?;
     }
-    if let Ok(v) = env::var("TIMELINE_ENERGY_THRESHOLD") {
-        cfg.energy_threshold = parse_env_value("TIMELINE_ENERGY_THRESHOLD", &v)?;
+    if let Ok(v) = env::var(ENV_ENERGY_THRESHOLD) {
+        cfg.energy_threshold = parse_env_value(ENV_ENERGY_THRESHOLD, &v)?;
     }
-    if let Ok(v) = env::var("TIMELINE_PARALLEL_FEATURES") {
-        cfg.parallel_features = parse_env_value("TIMELINE_PARALLEL_FEATURES", &v)?;
+    if let Ok(v) = env::var(ENV_PARALLEL_FEATURES) {
+        cfg.parallel_features = parse_env_value(ENV_PARALLEL_FEATURES, &v)?;
     }
     Ok(cfg)
 }

--- a/crates/movie-radio-timeline/src/config.rs
+++ b/crates/movie-radio-timeline/src/config.rs
@@ -3,7 +3,7 @@ use std::{env, fs, path::PathBuf};
 
 pub use movie_radio_types::{AnalysisConfig, MergeOptions};
 
-const VALID_VAD_ENGINES: [&str; 3] = ["energy", "spectral", "hybrid"];
+const VALID_VAD_ENGINES: [&str; 5] = ["energy", "spectral", "hybrid", "webrtc", "silero"];
 
 #[allow(clippy::too_many_arguments)]
 pub fn build_analysis_config(
@@ -226,6 +226,17 @@ mod tests {
             ..AnalysisConfig::default()
         };
         assert!(validate(&cfg).is_err());
+    }
+
+    #[test]
+    fn new_vad_engine_names_are_accepted() {
+        for engine in ["webrtc", "silero"] {
+            let cfg = AnalysisConfig {
+                vad_engine: engine.to_string(),
+                ..AnalysisConfig::default()
+            };
+            assert!(validate(&cfg).is_ok(), "{engine} should validate");
+        }
     }
 
     #[test]

--- a/plans/adr/0127-real-vad-engines.md
+++ b/plans/adr/0127-real-vad-engines.md
@@ -1,0 +1,57 @@
+# ADR-127: Real VAD Engines Behind Feature Flags
+
+**Status**: Accepted
+**Date**: 2026-09-04
+**Issues**: #253 (Phase 6.2)
+
+## Context
+
+`VadEngine::classify(&[Frame])` consumes pre-computed features (`Frame` carries
+rms/zcr/spectral stats, no raw samples). Sample-level engines cannot plug in:
+WebRTC VAD needs mono i16 frames; Silero VAD needs f32 windows with recurrent
+state. Researched 2026-09-04 against official docs:
+
+- `webrtc-vad` 0.4.0 ([docs.rs](https://docs.rs/webrtc-vad/latest/webrtc_vad/)):
+  rates 8/16/32/48 kHz, frames 10/20/30 ms, `is_voice_segment(&[i16])`,
+  modes Quality/LowBitrate/Aggressive/VeryAggressive. No model files, CPU trivial.
+  Our 16 kHz / 20 ms default = 320-sample frames, a native fit (f32→i16 convert).
+- `silero-vad-rust` 6.2.2 ([GitHub](https://github.com/sheldonix/silero-vad-rust)):
+  ONNX models **bundled** in the published package (`src/silero_vad/data/*.onnx`),
+  no build-time or runtime downloads (fits the no-auto-download policy).
+  Requires `ort 2.0.0-rc.10`; workspace pins rc.9 — both caret, so Cargo unifies
+  to one version. `forward_chunk` is stateful over exact 512-sample windows @16kHz;
+  CPU execution provider default. Runtime needs the ONNX dylib (`load-dynamic`,
+  same as the existing voice crate usage).
+- Alternative `wavekat-vad` rejected: its Silero backend downloads the model at
+  build time, breaking offline builds.
+
+## Decision
+
+1. Extend `VadEngine` with defaulted methods (backward compatible):
+   `uses_raw_samples() -> bool` (default `false`) and
+   `classify_samples(&[f32], sample_rate_hz, frame_ms) -> Result<VadResult>`
+   (default: bail "engine requires pre-computed frames"). Pipeline routes
+   sample-based engines on the mono signal before framing.
+2. `WebRtcVad` behind `webrtc-vad` feature; aggressiveness mapped from the
+   configured threshold; unsupported rate/frame combos rejected with a typed error.
+3. `SileroVad` behind `silero-vad` feature using `silero-vad-rust`
+   (`default-features = false` + `ort-load-dynamic`); 512-sample windowing
+   adapter over pipeline frames; per-file stream state (deterministic for
+   identical input). Real-model test behind env opt-in (`SILERO_INTEGRATION=1`,
+   repo convention per `AUDIO_CPP_INTEGRATION=1`); adapter + routing unit-tested
+   without model/dylib.
+4. `create_engine` accepts `webrtc`/`silero` unconditionally; when the feature
+   is compiled out it bails with "rebuild with `--features webrtc-vad`".
+   CLI `value_parser` and config `VALID_VAD_ENGINES` extended the same way
+   (fail at creation, not at arg parse, so `--help` stays stable).
+5. Default build unchanged: energy/spectral/hybrid, CPU-only, no new Deps.
+
+## Consequences
+
+- New optional deps: `webrtc-vad` (C code via `cc`, needs C compiler at build —
+  present in CI), `silero-vad-rust` (+ `ndarray` transitive, MIT).
+- Workspace `ort` may unify rc.9 → rc.10+; verified by full CI (local voice
+  build lacks clang, so unification risk is CI-gated).
+- Silero only supports 8/16 kHz: other rates rejected explicitly (no silent
+  resample inside the engine; pipeline resampling stays the caller's choice).
+- Determinism preserved: fixed windowing, no RNG, state reset per file.

--- a/plans/adr/0127-real-vad-engines.md
+++ b/plans/adr/0127-real-vad-engines.md
@@ -34,12 +34,18 @@ state. Researched 2026-09-04 against official docs:
    sample-based engines on the mono signal before framing.
 2. `WebRtcVad` behind `webrtc-vad` feature; aggressiveness mapped from the
    configured threshold; unsupported rate/frame combos rejected with a typed error.
-3. `SileroVad` behind `silero-vad` feature using `silero-vad-rust`
-   (`default-features = false` + `ort-load-dynamic`); 512-sample windowing
-   adapter over pipeline frames; per-file stream state (deterministic for
-   identical input). Real-model test behind env opt-in (`SILERO_INTEGRATION=1`,
-   repo convention per `AUDIO_CPP_INTEGRATION=1`); adapter + routing unit-tested
-   without model/dylib.
+3. `SileroVad` **DEFERRED**: `silero-vad-rust` 6.2.2 does not compile against
+   the workspace-unified `ort` rc.13 (it targets the rc.10-era API:
+   `execution_providers::CPUExecutionProvider`, non-generic `ort::Error`,
+   old `Tensor::from_array` bounds — all changed/removed in rc.13; verified
+   2026-09-04 via `cargo check -p movie-radio-pipeline --features silero-vad`).
+   The workspace lock already unified on rc.13 (voice crate is compatible), so
+   this is purely a `silero-vad-rust` release gap. Additionally there is no
+   weight-vendoring convention (`models/` does not exist; root-cleanliness
+   rules). Unblock path: upstream release supporting ort rc.13+, or an explicit
+   decision to vendor `silero_vad.onnx` (~2 MB, MIT) plus hand-rolled session
+   code over the workspace `ort`. The `silero` engine name stays reserved and
+   fails with a pointer to this ADR.
 4. `create_engine` accepts `webrtc`/`silero` unconditionally; when the feature
    is compiled out it bails with "rebuild with `--features webrtc-vad`".
    CLI `value_parser` and config `VALID_VAD_ENGINES` extended the same way
@@ -48,10 +54,11 @@ state. Researched 2026-09-04 against official docs:
 
 ## Consequences
 
-- New optional deps: `webrtc-vad` (C code via `cc`, needs C compiler at build —
-  present in CI), `silero-vad-rust` (+ `ndarray` transitive, MIT).
-- Workspace `ort` may unify rc.9 → rc.10+; verified by full CI (local voice
-  build lacks clang, so unification risk is CI-gated).
-- Silero only supports 8/16 kHz: other rates rejected explicitly (no silent
-  resample inside the engine; pipeline resampling stays the caller's choice).
-- Determinism preserved: fixed windowing, no RNG, state reset per file.
+- New optional dep: `webrtc-vad` (C code via `cc`, needs C compiler at build —
+  present in CI; verified compiling + tested locally with gcc).
+- `Cargo.lock` untouched (`ort` stays rc.13, no new transitive deps).
+- Silero deferred per §3 above; shipping WebRTC alone still satisfies the
+  "implement WebRTC or remove the option" half of Phase 6.2 and unblocks real
+  engine comparison against energy/spectral baselines.
+- Determinism preserved: fresh WebRTC instance per call, zero-padded tails,
+  no RNG.

--- a/plans/adr/0127-real-vad-engines.md
+++ b/plans/adr/0127-real-vad-engines.md
@@ -35,7 +35,8 @@ state. Researched 2026-09-04 against official docs:
 2. `WebRtcVad` behind `webrtc-vad` feature; aggressiveness mapped from the
    configured threshold; unsupported rate/frame combos rejected with a typed error.
 3. `SileroVad` **DEFERRED**: `silero-vad-rust` 6.2.2 does not compile against
-   the workspace-unified `ort` rc.13 (it targets the rc.10-era API:
+   `ort` rc.13 as resolved in `Cargo.lock` (the manifest declares
+   `ort ^2.0.0-rc.9`, which admits rc.13; the crate targets the rc.10-era API:
    `execution_providers::CPUExecutionProvider`, non-generic `ort::Error`,
    old `Tensor::from_array` bounds — all changed/removed in rc.13; verified
    2026-09-04 via `cargo check -p movie-radio-pipeline --features silero-vad`).


### PR DESCRIPTION
Refs #253 (Phase 6.2), ADR-127.

**What**: real WebRTC VAD engine + trait extension so sample-level engines can plug into the frame-based pipeline.

- `VadEngine` gains defaulted `uses_raw_samples()` / `classify_samples()`; `classify_with_engine` router used in both extract paths (chunked carries sample warmup now)
- `WebRtcVad` (`webrtc-vad` 0.4, optional, default-off): 16kHz/20ms native fit, threshold→aggressiveness mapping, zero-padded tails for frame alignment, fresh instance per call (upstream `Vad` is `!Send`, `unsafe` forbidden here)
- `create_engine` accepts `webrtc`/`silero` always; helpful rebuild/ADR errors when unavailable. CLI + config allowlists extended.
- 11 vad tests green incl. real-inference determinism (default + `webrtc-vad` features verified locally)

**Silero deferred with evidence** (ADR-127 §3): `silero-vad-rust` 6.2.2 targets pre-rc.13 ort API, workspace unified on rc.13; no weight-vendoring convention. Unblock path documented.

Verification: fmt/clippy/tests green locally (default + webrtc-vad); full workspace + silero-absence + timeline tests via CI.

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a broad pipeline and CLI configuration change that introduces WebRTC VAD engine routing behind a feature flag. The change spans core processing stages, VAD implementation, configuration, dependencies, and documentation, with critical graph reach but no individually high-risk files.*

**🔴 CRITICAL blast radius. A Rust pipeline and CLI configuration change centered on VAD engine selection reaches 20 dependents across the processing and command handling surface.**

The core review area is `crates/movie-radio-pipeline/src/pipeline/mod.rs`, which contains changes to `extract_timeline_chunked`, `run_pipeline`, `smoothing_stage`, `speech_segments_stage`, and `merging_stage`. Review the routing through `create_engine` and `adapt_spectral_thresholds` in `crates/movie-radio-pipeline/src/pipeline/vad/mod.rs`, alongside the VAD implementation in `crates/movie-radio-pipeline/src/pipeline/vad/engine.rs` and `crates/movie-radio-pipeline/src/pipeline/vad/webrtc.rs`. The affected execution surface includes 71 flows.

Impact is distributed across the human-named `Handlers`, `Pipeline`, `Vad`, `Voice`, and `Segmenter` modules, with CLI and environment configuration changes in `crates/movie-radio-timeline/src/cli.rs` and `crates/movie-radio-timeline/src/config.rs`. Check that `vad_engine`, `Commands`, `apply_env_overrides`, and `parse_env_value` align with the pipeline engine creation path, then review the related dependency manifests and configuration documentation in `Cargo.toml`, `crates/movie-radio-pipeline/Cargo.toml`, `crates/movie-radio-timeline/Cargo.toml`, and `README.md`.

_Added by GitNexus for PR #254. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->