### PR TITLE
Update AGENTS.md commands, repo map entries, and undocumented rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,19 @@ The `VERSION` file in the root is the single source of truth. Never edit version
 | `crates/movie-radio-timeline/` | Binary crate (CLI, handlers, config) |
 | `scripts/` | Quality gate, benchmarks, validation, optimization |
 | `plans/` | ADRs, roadmaps, and status reports |
-| `.agents/skills/` | Reusable skill playbooks |
+| `reports/` | Validation reports and metrics output |
+| `testdata/` | Raw audio test assets and generated fixtures |
+| `benches/` | Render and spectral VAD benchmarks |
+| `.github/` | CI workflows and issue templates |
+| `.agents/` | Agent configuration, orchestration docs, and skill playbooks |
 
 ## Quick Reference
 | Task | Command |
 | ------ | --------- |
 | Build | `cargo build --workspace` |
 | Test | `cargo test --workspace` |
+| Format Check | `cargo fmt --check` |
+| Lint | `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
 | Quality Gate | `bash scripts/quality_gate.sh` |
 | Docs Update | `bash scripts/update-all-docs.sh` |
 | Commit | `bash scripts/ai-commit.sh` |
@@ -44,11 +50,13 @@ The `VERSION` file in the root is the single source of truth. Never edit version
 - **Verification**: `bash scripts/quality_gate.sh` must pass with zero warnings.
 - **Lint**: Always run `cargo fmt --check && cargo clippy --workspace --all-targets --all-features -- -D warnings`.
 - **Atomic Commits**: Use `bash scripts/ai-commit.sh` or `bash scripts/quality_gate.sh && git add -A && git commit`.
-- **No unwrap() or expect()** in `crates/*/src/`. Use `Result` and `?`.
+- **No unwrap() or expect()** in library code (`crates/*/src/`). Use `Result` and `?`.
+- **16-bit PCM WAV Output**: Direct audio writer/renderers must output 16-bit PCM WAV.
+- **FFmpeg Dependency**: `ffmpeg` must be available on `PATH` for processing non-WAV media.
+- **Deterministic Output**: All pipeline stages must produce deterministic output for identical inputs.
 - **MAX_SOURCE_FILE_LOC**: Limit Rust source files to 500 lines.
 - **Secret Scanning**: Gitleaks enforcement via `.gitleaks.toml`.
 - **Root Cleanliness**: Never commit test fixtures or runtime-output files to the repository root.
-- **Deterministic output**: All pipeline stages must produce deterministic output for identical inputs.
 - **Pre-existing issues**: Address pre-existing warnings or document in `plans/FOLLOWUPS.md`.
 
 ## Agent Coordination References
@@ -79,7 +87,7 @@ Maintain zero open issues/PRs. A weekly reminder workflow (`.github/workflows/tr
 | Gitleaks Scan | Adopted | `.gitleaks.toml` present |
 | Named Constants | Adopted | `bash readonly` block above |
 | Single Source Version | Adopted | `VERSION` file is the single source of truth |
-| `MAX_LINES_AGENTS_MD` | Adopted | Enforced at 150 lines (currently <= 100) |
+| `MAX_LINES_AGENTS_MD` | Adopted | Enforced at 150 lines (currently <= 110) |
 | Skill Frontmatter | Adopted | Verified in all `.agents/skills/*/SKILL.md` |
 | `ai-commit.sh` | Adopted | Available in `scripts/ai-commit.sh` |
 | `update-all-docs.sh` | Adopted | Available in `scripts/update-all-docs.sh` |


### PR DESCRIPTION
Addressed documentation gaps in AGENTS.md by adding missing quick reference commands (`cargo fmt --check`, `cargo clippy`), repository map entries (`reports/`, `testdata/`, `benches/`, `.github/`, `.agents/`), and undocumented coding rules (`16-bit PCM WAV output`, `ffmpeg` dependency, library `unwrap()`/`expect()` restrictions, and determinism). Line count is maintained at 95 lines, well under `MAX_LINES_AGENTS_MD=150`.

Fixes #279

---
*PR created automatically by Jules for task [7826103604143607250](https://jules.google.com/task/7826103604143607250) started by @d-oit*