### PR TITLE
ci: add release automation workflow for annotated tag builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,14 +246,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Check VERSION matches Cargo.toml
-        run: |
-          VERSION=$(cat VERSION)
-          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          if [[ "$VERSION" != "$CARGO_VERSION" ]]; then
-            echo "VERSION file ($VERSION) does not match Cargo.toml ($CARGO_VERSION)"
-            exit 1
-          fi
-          echo "VERSION consistency check passed: $VERSION"
+        run: bash scripts/check_version.sh
 
   # ───────────────────────────────────────────────────
   ci-success:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release Automation
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  release:
+    name: Release Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install System Dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg libasound2-dev
+
+      - name: Validate VERSION and Annotated Tag
+        run: bash scripts/check_version.sh "${{ github.ref_name }}"
+
+      - name: Build Release Binary
+        run: cargo build --release -p movie-radio-timeline
+
+      - name: Package Release Artifacts
+        run: |
+          VERSION=$(tr -d '[:space:]' < VERSION)
+
+          mkdir -p dist/binary
+          cp target/release/movie-radio-timeline dist/binary/
+          if [[ -f README.md ]]; then cp README.md dist/binary/; fi
+          if [[ -f LICENSE ]]; then cp LICENSE dist/binary/; fi
+          tar -czvf "movie-radio-timeline-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz" -C dist/binary .
+
+          mkdir -p dist/schemas
+          cp schema/*.schema.json dist/schemas/
+          tar -czvf "schemas-v${VERSION}.tar.gz" -C dist/schemas .
+
+      - name: Upload Artifacts to Action Run
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-artifacts
+          path: |
+            movie-radio-timeline-*.tar.gz
+            schemas-*.tar.gz
+            schema/*.schema.json
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            movie-radio-timeline-*.tar.gz
+            schemas-*.tar.gz
+            schema/*.schema.json
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/check_version.sh
+++ b/scripts/check_version.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/check_version.sh
+# Validates VERSION file consistency with Cargo.toml and optional git tag.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION_FILE="$REPO_ROOT/VERSION"
+CARGO_TOML="$REPO_ROOT/Cargo.toml"
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+  echo "❌ Error: VERSION file not found at $VERSION_FILE"
+  exit 1
+fi
+
+VERSION=$(tr -d '[:space:]' < "$VERSION_FILE")
+
+if [[ -z "$VERSION" ]]; then
+  echo "❌ Error: VERSION file is empty"
+  exit 1
+fi
+
+if [[ ! -f "$CARGO_TOML" ]]; then
+  echo "❌ Error: Cargo.toml not found at $CARGO_TOML"
+  exit 1
+fi
+
+CARGO_VERSION=$(grep '^version' "$CARGO_TOML" | head -n 1 | sed 's/.*"\(.*\)".*/\1/' | tr -d '[:space:]')
+
+if [[ "$VERSION" != "$CARGO_VERSION" ]]; then
+  echo "❌ Error: VERSION file ($VERSION) does not match Cargo.toml ($CARGO_VERSION)"
+  exit 1
+fi
+
+echo "✅ VERSION file ($VERSION) matches Cargo.toml ($CARGO_VERSION)"
+
+TAG_INPUT="${1:-}"
+if [[ -n "$TAG_INPUT" ]]; then
+  # Remove refs/tags/ prefix if passed as a full ref
+  TAG_NAME="${TAG_INPUT#refs/tags/}"
+  TAG_VERSION="${TAG_NAME#v}"
+
+  if [[ "$TAG_VERSION" != "$VERSION" ]]; then
+    echo "❌ Error: Tag version '$TAG_VERSION' (from '$TAG_NAME') does not match VERSION file ($VERSION)"
+    exit 1
+  fi
+  echo "✅ Tag version '$TAG_VERSION' matches VERSION file ($VERSION)"
+
+  OBJ_TYPE=$(git cat-file -t "refs/tags/$TAG_NAME" 2>/dev/null || git cat-file -t "$TAG_NAME" 2>/dev/null || echo "")
+  if [[ "$OBJ_TYPE" != "tag" ]]; then
+    echo "❌ Error: Tag '$TAG_NAME' is not an annotated tag object (got '$OBJ_TYPE'). Release requires an annotated tag."
+    exit 1
+  fi
+  echo "✅ Tag '$TAG_NAME' is a valid annotated tag object"
+fi


### PR DESCRIPTION
Add tag-triggered release workflow (.github/workflows/release.yml) and single-source VERSION verification script (scripts/check_version.sh).

Key Changes:
- Added `scripts/check_version.sh` to enforce VERSION single-source policy against Cargo.toml, tag version strings, and verify annotated tag objects in Git.
- Updated `.github/workflows/ci.yml` version-check job to execute `scripts/check_version.sh`.
- Created `.github/workflows/release.yml` triggered on `v*` tag pushes and `workflow_dispatch`. It validates the tag and version, compiles `movie-radio-timeline` in release mode, packages binary and `schema/` artifacts, and publishes them to GitHub Releases and action run artifacts.

Fixes #282

---
*PR created automatically by Jules for task [5976966510625408325](https://jules.google.com/task/5976966510625408325) started by @d-oit*

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a release automation and CI configuration change. It has no graph-traced dependent or execution-flow reach, but the workflow changes carry elevated operational risk.*

**🟠 HIGH blast radius. A CI and release automation change across `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `scripts/check_version.sh`, with impact concentrated in high-risk workflow configuration.**

Review `.github/workflows/ci.yml` and `.github/workflows/release.yml` first, since both are HIGH risk files and are the primary locations for the annotated-tag build automation described by the PR title.

`scripts/check_version.sh` is the supporting script change. There are no resolved dependents, affected flows, or cross-repository consumers, so the review focus is on the correctness and safety of the local CI and release workflow definitions.

_Added by GitNexus for PR #289. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->