### PR TITLE
Implement GOAP VerifyQuality and ApplyLearnings actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,9 +2189,11 @@ dependencies = [
  "movie-radio-pipeline",
  "movie-radio-types",
  "movie-radio-validation",
+ "movie-radio-verification",
  "movie-radio-voice",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/movie-radio-goap/Cargo.toml
+++ b/crates/movie-radio-goap/Cargo.toml
@@ -11,6 +11,7 @@ movie-radio-pipeline.workspace = true
 movie-radio-voice.workspace = true
 movie-radio-learning.workspace = true
 movie-radio-validation.workspace = true
+movie-radio-verification.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 hound.workspace = true
@@ -18,6 +19,9 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/movie-radio-goap/src/actions/learn.rs
+++ b/crates/movie-radio-goap/src/actions/learn.rs
@@ -1,0 +1,202 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use tracing::info;
+
+use crate::PipelineContext;
+
+pub async fn execute_apply_learnings(ctx: &mut PipelineContext) -> Result<()> {
+    info!("Applying learnings and persisting execution trace");
+
+    // 1. Calibration profile updates
+    let cal_path = ctx
+        .calibration_report_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("analysis/learnings/latest-calibration.json"));
+
+    if cal_path.exists() {
+        let out_profile = ctx
+            .updated_profile_path
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("analysis/profiles/updated-profile.json"));
+        movie_radio_learning::calibrator::apply_calibration_report(&cal_path, &out_profile)?;
+        info!(
+            cal_report = %cal_path.display(),
+            out_profile = %out_profile.display(),
+            "Applied calibration report update"
+        );
+    }
+
+    // 2. Adaptive threshold updates
+    let state_path = ctx
+        .learning_state_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("analysis/thresholds/learning-state.json"));
+    let mut state = movie_radio_learning::adaptive_thresholds::load_learning_state(&state_path)
+        .unwrap_or_else(|_| movie_radio_learning::adaptive_thresholds::create_learning_state(20));
+
+    if let Some(ref report) = ctx.verification_report {
+        for (i, result) in report.segment_results.iter().enumerate() {
+            movie_radio_learning::adaptive_thresholds::record_verification_result(
+                &mut state,
+                i,
+                result.is_suspicious,
+                result.spectral_features.spectral_entropy,
+                result.spectral_features.spectral_flatness,
+                result.spectral_features.rms,
+                result.spectral_features.centroid_hz,
+            );
+        }
+        movie_radio_learning::adaptive_thresholds::adjust_thresholds_for_fp_rate(&mut state);
+        movie_radio_learning::adaptive_thresholds::save_learning_state(&state, &state_path)?;
+    }
+
+    // 3. LearningDb run trace persistence
+    let db_path = ctx
+        .learning_db_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("analysis/thresholds/learning.db"));
+
+    let report_opt = ctx.verification_report.clone();
+    let db_path_clone = db_path.clone();
+
+    tokio::task::spawn_blocking(move || {
+        if let Some(parent) = db_path_clone.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("Failed to create runtime for LearningDb interaction")?;
+
+        let db = rt.block_on(movie_radio_learning::database::LearningDb::new(
+            &db_path_clone,
+        ))?;
+
+        let run_id = format!(
+            "goap_run_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        );
+
+        let _exp_id = rt
+            .block_on(db.record_experiment(&run_id, "GOAP Execution", Some("Pipeline run trace")))
+            .context("Failed to record GOAP experiment run trace")?;
+
+        if let Some(ref report) = report_opt {
+            for (i, result) in report.segment_results.iter().enumerate() {
+                let segment = movie_radio_learning::database::VerifiedSegment {
+                    start_ms: result.start_ms as i64,
+                    end_ms: result.end_ms as i64,
+                    confidence: result.original_confidence as f64,
+                    spectral_features: movie_radio_learning::database::SpectralFeatures {
+                        rms: result.spectral_features.rms as f64,
+                        zcr: result.spectral_features.zcr as f64,
+                        spectral_flux: result.spectral_features.spectral_flux as f64,
+                        spectral_flatness: result.spectral_features.spectral_flatness as f64,
+                        spectral_entropy: result.spectral_features.spectral_entropy as f64,
+                        centroid_hz: result.spectral_features.centroid_hz as f64,
+                        low_band_ratio: result.spectral_features.low_band_ratio as f64,
+                        high_band_ratio: result.spectral_features.high_band_ratio as f64,
+                    },
+                    was_false_positive: result.is_suspicious,
+                };
+
+                let seg_id = rt.block_on(db.record_verification(segment))?;
+
+                if let Some(fps) = report.segment_fingerprints.get(i) {
+                    rt.block_on(db.record_fingerprints(seg_id, fps))?;
+                }
+            }
+        }
+
+        info!(
+            db_path = %db_path_clone.display(),
+            run_id = %run_id,
+            "Learnings and execution trace persisted to LearningDb"
+        );
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .await??;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use movie_radio_types::TimelineOutput;
+    use movie_radio_verification::verification::{
+        AppliedThresholds, SegmentVerification, SpectralFeatures, VerificationReport,
+        VerificationStatus, VerificationSummary,
+    };
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_apply_learnings_persists_to_db() {
+        let db_file = NamedTempFile::new().unwrap();
+        let db_path = db_file.path().to_path_buf();
+
+        let state_file = NamedTempFile::new().unwrap();
+        let state_path = state_file.path().to_path_buf();
+
+        let mut ctx = PipelineContext::new(PathBuf::from("movie.mp4"), PathBuf::from("out.wav"));
+        ctx.learning_db_path = Some(db_path.clone());
+        ctx.learning_state_path = Some(state_path.clone());
+
+        let report = VerificationReport {
+            verified_timeline: TimelineOutput {
+                file: "test.wav".to_string(),
+                analysis_sample_rate: 16_000,
+                frame_ms: 10,
+                segments: vec![],
+            },
+            segment_results: vec![SegmentVerification {
+                start_ms: 0,
+                end_ms: 1000,
+                original_confidence: 0.8,
+                verification_status: VerificationStatus::Verified,
+                spectral_features: SpectralFeatures::default(),
+                is_verified: true,
+                is_suspicious: false,
+                reason: None,
+            }],
+            segment_fingerprints: vec![vec![]],
+            summary: VerificationSummary {
+                total_segments: 1,
+                verified_count: 1,
+                suspicious_count: 0,
+                rejected_count: 0,
+                false_positive_rate: 0.0,
+                average_confidence: 0.8,
+                thresholds_applied: AppliedThresholds {
+                    entropy_min: 3.5,
+                    entropy_max: 7.0,
+                    flatness_max: 0.45,
+                    energy_min: 0.001,
+                    centroid_min: 100.0,
+                    centroid_max: 6000.0,
+                },
+            },
+        };
+
+        ctx.verification_report = Some(report);
+
+        let result = execute_apply_learnings(&mut ctx).await;
+        assert!(result.is_ok());
+
+        let db = movie_radio_learning::database::LearningDb::new(&db_path)
+            .await
+            .unwrap();
+
+        let total_verifications = db.get_total_verifications().await.unwrap();
+        assert_eq!(total_verifications, 1);
+
+        let experiments = db.list_experiments().await.unwrap();
+        assert!(!experiments.is_empty());
+        assert!(experiments[0].experiment_id.starts_with("goap_run_"));
+    }
+}

--- a/crates/movie-radio-goap/src/actions/mod.rs
+++ b/crates/movie-radio-goap/src/actions/mod.rs
@@ -8,6 +8,9 @@ use crate::{Action, PipelineContext, WorldState};
 use movie_radio_pipeline::pipeline::decode::decode_audio;
 use movie_radio_pipeline::pipeline::extract_timeline;
 
+pub mod learn;
+pub mod quality;
+
 #[derive(Debug, Default)]
 pub struct DecodeMovie;
 
@@ -350,9 +353,8 @@ impl Action for VerifyQuality {
         2.0
     }
 
-    async fn execute(&self, _ctx: &mut PipelineContext) -> Result<()> {
-        info!("Quality verification (placeholder)");
-        Ok(())
+    async fn execute(&self, ctx: &mut PipelineContext) -> Result<()> {
+        quality::execute_verify_quality(ctx).await
     }
 }
 
@@ -380,9 +382,8 @@ impl Action for ApplyLearnings {
         0.5
     }
 
-    async fn execute(&self, _ctx: &mut PipelineContext) -> Result<()> {
-        info!("Applying learnings (placeholder)");
-        Ok(())
+    async fn execute(&self, ctx: &mut PipelineContext) -> Result<()> {
+        learn::execute_apply_learnings(ctx).await
     }
 }
 
@@ -448,10 +449,8 @@ mod tests {
         let segments = build_narration_segments(&scripts, &narration, &assembler);
 
         assert_eq!(segments.len(), 2);
-        // First surviving segment belongs to script 0, not shifted by the skip.
         assert_eq!(segments[0].start_sample, 16_000);
         assert_eq!(segments[0].samples.len(), 800);
-        // Second surviving segment must pair with script 2 (3_000 ms -> 48_000).
         assert_eq!(segments[1].start_sample, 48_000);
         assert_eq!(segments[1].samples.len(), 1_600);
     }

--- a/crates/movie-radio-goap/src/actions/quality.rs
+++ b/crates/movie-radio-goap/src/actions/quality.rs
@@ -1,0 +1,131 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use tracing::{info, warn};
+
+use crate::PipelineContext;
+use movie_radio_verification::verification::verify_timeline;
+
+pub async fn execute_verify_quality(ctx: &mut PipelineContext) -> Result<()> {
+    let timeline = ctx.timeline.as_ref().context("Timeline not extracted")?;
+
+    let media_path = if ctx.movie_path.exists() {
+        ctx.movie_path.clone()
+    } else if ctx.output_path.exists() {
+        ctx.output_path.clone()
+    } else {
+        ctx.movie_path.clone()
+    };
+
+    let report_path = ctx
+        .verification_report_path
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("analysis/verification_report.json"));
+
+    info!(
+        media = %media_path.display(),
+        report_path = %report_path.display(),
+        "Running spectral quality verification and fingerprint scoring"
+    );
+
+    let media_path_clone = media_path.clone();
+    let timeline_clone = timeline.clone();
+    let report_path_clone = report_path.clone();
+    let db_path_clone = ctx.learning_db_path.clone();
+
+    let report = tokio::task::spawn_blocking(move || {
+        verify_timeline(
+            &media_path_clone,
+            &timeline_clone,
+            &report_path_clone,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            true,
+            10,
+            db_path_clone,
+        )
+    })
+    .await??;
+
+    info!(
+        verified = report.summary.verified_count,
+        suspicious = report.summary.suspicious_count,
+        rejected = report.summary.rejected_count,
+        fp_rate = format!("{:.2}%", report.summary.false_positive_rate * 100.0),
+        "Quality verification complete"
+    );
+
+    if report.summary.false_positive_rate > 0.5
+        || (report.summary.total_segments > 0 && report.summary.verified_count == 0)
+    {
+        warn!(
+            fp_rate = report.summary.false_positive_rate,
+            verified = report.summary.verified_count,
+            "Quality verification failed threshold; requesting replan"
+        );
+        ctx.replan_requested = true;
+    }
+
+    ctx.verification_report = Some(report);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use movie_radio_types::{Segment, SegmentKind, TimelineOutput};
+    use tempfile::NamedTempFile;
+
+    fn generate_test_wav() -> NamedTempFile {
+        let file = NamedTempFile::new().unwrap();
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 16_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::new(file.reopen().unwrap(), spec).unwrap();
+        for i in 0..16_000 {
+            let sample = ((i as f32 * 0.05).sin() * 10000.0) as i16;
+            writer.write_sample(sample).unwrap();
+        }
+        writer.finalize().unwrap();
+        file
+    }
+
+    #[tokio::test]
+    async fn test_verify_quality_execution() {
+        let wav = generate_test_wav();
+        let wav_path = wav.path().to_path_buf();
+        let report_file = NamedTempFile::new().unwrap();
+        let report_path = report_file.path().to_path_buf();
+
+        let timeline = TimelineOutput {
+            file: wav_path.display().to_string(),
+            analysis_sample_rate: 16_000,
+            frame_ms: 10,
+            segments: vec![Segment {
+                start_ms: 0,
+                end_ms: 1000,
+                kind: SegmentKind::NonVoice,
+                confidence: 0.9,
+                tags: vec![],
+                prompt: None,
+                sfx_trigger: None,
+            }],
+        };
+
+        let mut ctx = PipelineContext::new(wav_path.clone(), wav_path.clone());
+        ctx.timeline = Some(timeline);
+        ctx.verification_report_path = Some(report_path);
+
+        let result = execute_verify_quality(&mut ctx).await;
+        assert!(result.is_ok());
+        assert!(ctx.verification_report.is_some());
+        let rep = ctx.verification_report.unwrap();
+        assert_eq!(rep.summary.total_segments, 1);
+    }
+}

--- a/crates/movie-radio-goap/src/lib.rs
+++ b/crates/movie-radio-goap/src/lib.rs
@@ -48,6 +48,13 @@ pub struct PipelineContext {
     pub narration_audio: Vec<Option<movie_radio_voice::AudioOutput>>,
     pub original_audio: Option<Vec<f32>>,
     pub sample_rate: u32,
+    pub verification_report: Option<movie_radio_verification::VerificationReport>,
+    pub verification_report_path: Option<PathBuf>,
+    pub learning_db_path: Option<PathBuf>,
+    pub learning_state_path: Option<PathBuf>,
+    pub calibration_report_path: Option<PathBuf>,
+    pub updated_profile_path: Option<PathBuf>,
+    pub replan_requested: bool,
 }
 
 impl PipelineContext {
@@ -64,6 +71,13 @@ impl PipelineContext {
             scripts: None,
             narration_audio: Vec::new(),
             original_audio: None,
+            verification_report: None,
+            verification_report_path: None,
+            learning_db_path: None,
+            learning_state_path: None,
+            calibration_report_path: None,
+            updated_profile_path: None,
+            replan_requested: false,
         }
     }
 }

--- a/crates/movie-radio-goap/src/orchestrator.rs
+++ b/crates/movie-radio-goap/src/orchestrator.rs
@@ -44,8 +44,9 @@ impl Orchestrator {
                 action.execute(ctx).await?;
                 self.current_state = action.apply(&self.current_state);
 
-                if self.should_replan() {
-                    warn!("External trigger detected, replanning...");
+                if self.should_replan(ctx) {
+                    warn!("Replan requested by pipeline context, replanning...");
+                    ctx.replan_requested = false;
                     break;
                 }
             }
@@ -55,13 +56,14 @@ impl Orchestrator {
         Ok(())
     }
 
-    fn should_replan(&self) -> bool {
-        false
+    fn should_replan(&self, ctx: &PipelineContext) -> bool {
+        ctx.replan_requested
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::actions::get_all_actions;
     use crate::planner::Planner;
     use crate::WorldState;
@@ -80,5 +82,23 @@ mod tests {
         let plan = plan.unwrap();
         assert!(plan.contains(&"decode_movie".to_string()));
         assert!(plan.contains(&"assemble_radio_play".to_string()));
+    }
+
+    #[test]
+    fn test_orchestrator_should_replan() {
+        use std::path::PathBuf;
+
+        let start = WorldState::default();
+        let goal = WorldState {
+            quality_verified: true,
+            ..WorldState::default()
+        };
+        let orch = Orchestrator::new(start, goal, vec![]);
+        let mut ctx = PipelineContext::new(PathBuf::from("in.mp4"), PathBuf::from("out.wav"));
+
+        assert!(!orch.should_replan(&ctx));
+
+        ctx.replan_requested = true;
+        assert!(orch.should_replan(&ctx));
     }
 }


### PR DESCRIPTION
This change implements the GOAP `VerifyQuality` and `ApplyLearnings` actions:
- Extends `PipelineContext` with fields for tracking verification reports, database paths, and replan requests.
- Restructures `movie-radio-goap::actions` into modular subfiles (`mod.rs`, `quality.rs`, `learn.rs`) respecting file LOC limits.
- Implements `VerifyQuality` action to perform spectral timeline verification (`movie-radio-verification`), store `VerificationReport`, and set `replan_requested` if false-positive/suspicious thresholds fail.
- Implements `ApplyLearnings` action to apply calibration reports, adjust adaptive thresholds, and record execution run trace, verified segments, and fingerprints in `LearningDb`.
- Enables dynamic replanning in `Orchestrator::should_replan` based on `replan_requested`.
- Uses `tokio::task::spawn_blocking` to safely execute blocking verification and database tasks within async runtime contexts.
- Adds comprehensive unit tests covering actions and orchestrator replanning.

Fixes #261

---
*PR created automatically by Jules for task [16184579252236230015](https://jules.google.com/task/16184579252236230015) started by @d-oit*

<!-- gitnexus-pr-summary:v1:start -->

---

### 📝 Summary by GitNexus

## Summary

*This appears to be a focused Rust GOAP change that adds quality and learning action wiring while updating the planner context and orchestration behavior. Its reach is direct rather than transitive, with review attention centered on action semantics and replanning.*

**🟠 HIGH blast radius. A Rust GOAP change in `crates/movie-radio-goap` reaches 8 direct dependents through the action, context, and orchestrator code.**

The change is concentrated in `crates/movie-radio-goap/src/lib.rs`, especially `PipelineContext`, `Action`, and the `new`, `effects`, `cost`, and `is_valid` functions. Review the interaction between those action contract methods and the new action files, `crates/movie-radio-goap/src/actions/quality.rs` and `crates/movie-radio-goap/src/actions/learn.rs`, along with their registration in `crates/movie-radio-goap/src/actions/mod.rs`.

`crates/movie-radio-goap/src/orchestrator.rs` also changes `Orchestrator`, `run`, and `should_replan`, with updates in its `tests` module. The 3 affected flows and direct dependent reach make the orchestration and replanning path the first place to verify that the added actions integrate consistently with the existing GOAP execution lifecycle.

_Added by GitNexus for PR #294. Edit freely — this block is replaced on the next review, everything above it is left untouched._
<!-- gitnexus-pr-summary:v1:end -->